### PR TITLE
Adds bundle support to block builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.11.24", features = ["blocking", "json"] }
 ruint = "1.12.1"
 serde_json = "1.0"
-thiserror = "1.0.58"
+thiserror = "1.0.68"
 tokio = { version = "1.36.0", features = ["full", "macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.18"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ aws-sdk-kms = "1.15.0"
 hex = { package = "const-hex", version = "1", default-features = false, features = [
     "alloc",
 ] }
+
+signet-types = { git = "ssh://git@github.com/init4tech/signet-node.git" }
+
 serde = { version = "1.0.197", features = ["derive"] }
 tracing = "0.1.40"
 

--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -2,9 +2,9 @@
 
 use builder::config::BuilderConfig;
 use builder::service::serve_builder_with_span;
+use builder::tasks::bundler::BundlePoller;
 use builder::tasks::oauth::Authenticator;
 use builder::tasks::tx_poller::TxPoller;
-use builder::tasks::bundler::BundlePoller;
 
 use tokio::select;
 

--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -42,6 +42,7 @@ async fn main() -> eyre::Result<()> {
     let (submit_channel, submit_jh) = submit.spawn();
     let (tx_channel, bundle_channel, build_jh) = builder.spawn(submit_channel);
     let tx_poller_jh = tx_poller.spawn(tx_channel.clone());
+    let bundle_poller_jh = bundle_poller.spawn(bundle_channel);
 
     let server = serve_builder_with_span(tx_channel, ([0, 0, 0, 0], port), span);
 
@@ -57,6 +58,9 @@ async fn main() -> eyre::Result<()> {
         }
         _ = tx_poller_jh => {
             tracing::info!("tx_poller finished");
+        }
+        _ = bundle_poller_jh => {
+            tracing::info!("bundle_poller finished");
         }
     }
 

--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -15,7 +15,7 @@ async fn main() -> eyre::Result<()> {
 
     let config = BuilderConfig::load_from_env()?.clone();
     let provider = config.connect_provider().await?;
-    let authenticator = Authenticator::new(&config).await?;
+    let authenticator = Authenticator::new(&config);
 
     tracing::debug!(
         rpc_url = config.host_rpc_url.as_ref(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ const BUILDER_REWARDS_ADDRESS: &str = "BUILDER_REWARDS_ADDRESS";
 const ROLLUP_BLOCK_GAS_LIMIT: &str = "ROLLUP_BLOCK_GAS_LIMIT";
 const TX_POOL_URL: &str = "TX_POOL_URL";
 const TX_POOL_POLL_INTERVAL: &str = "TX_POOL_POLL_INTERVAL";
+const AUTH_TOKEN_REFRESH_INTERVAL: &str = "AUTH_TOKEN_REFRESH_INTERVAL";
 const TX_POOL_CACHE_DURATION: &str = "TX_POOL_CACHE_DURATION";
 const OAUTH_CLIENT_ID: &str = "OAUTH_CLIENT_ID";
 const OAUTH_CLIENT_SECRET: &str = "OAUTH_CLIENT_SECRET";
@@ -82,6 +83,8 @@ pub struct BuilderConfig {
     pub oauth_token_url: String,
     /// OAuth audience for the builder.
     pub oauth_audience: String,
+    /// The oauth token refresh interval in seconds.
+    pub oauth_token_refresh_interval: u64,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -159,6 +162,7 @@ impl BuilderConfig {
             oauth_authenticate_url: load_string(OAUTH_AUTHENTICATE_URL)?,
             oauth_token_url: load_string(OAUTH_TOKEN_URL)?,
             oauth_audience: load_string(OAUTH_AUDIENCE)?,
+            oauth_token_refresh_interval: load_u64(AUTH_TOKEN_REFRESH_INTERVAL)?,
         })
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -105,7 +105,6 @@ pub async fn ingest_raw_handler(
 ) -> Result<Response, AppError> {
     let body = body.strip_prefix("0x").unwrap_or(&body);
     let buf = hex::decode(body).map_err(AppError::bad_req)?;
-
     let envelope = TxEnvelope::decode_2718(&mut buf.as_slice()).map_err(AppError::bad_req)?;
 
     ingest_handler(State(state), Json(envelope)).await

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -77,6 +77,8 @@ impl InProgressBlock {
 
         if let Ok(txs) = txs {
             self.unseal();
+            // extend the transactions with the decoded transactions.
+            // As this builder does not provide bundles landing "top of block", its fine to just extend.
             self.transactions.extend(txs);
         } else {
             tracing::error!("failed to decode bundle. dropping");

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -64,6 +64,7 @@ impl InProgressBlock {
     }
 
     /// Ingest a bundle into the in-progress block.
+    /// Ignores Signed Orders for now.
     pub fn ingest_bundle(&mut self, bundle: Bundle) {
         tracing::info!(bundle = %bundle.id, "ingesting bundle");
 

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -110,7 +110,11 @@ impl BlockBuilder {
     pub fn spawn(
         self,
         outbound: mpsc::UnboundedSender<InProgressBlock>,
-    ) -> (mpsc::UnboundedSender<TxEnvelope>, mpsc::UnboundedSender<Bundle>, JoinHandle<()>) {
+    ) -> (
+        mpsc::UnboundedSender<TxEnvelope>,
+        mpsc::UnboundedSender<Bundle>,
+        JoinHandle<()>,
+    ) {
         let mut in_progress = InProgressBlock::default();
 
         let (tx_sender, mut tx_inbound) = mpsc::unbounded_channel();

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -1,0 +1,75 @@
+pub use crate::config::BuilderConfig;
+use eyre::Error;
+use reqwest::{Client, Url};
+use serde::{Deserialize, Serialize};
+use serde_json::from_slice;
+use signet_types::SignetEthBundle;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tracing::{debug, info};
+
+// TODO: Consider exporting this type from the signet-types crate instead of duplicating it here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Bundle {
+    pub id: String,
+    pub bundle: SignetEthBundle,
+}
+
+/// Response from the tx-pool containing a list of bundles.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxPoolBundleResponse {
+    pub bundles: Vec<Bundle>,
+}
+
+pub struct BundleFetcher {
+    pub config: BuilderConfig,
+}
+
+/// Implements a poller for the block builder to pull bundles from the tx cache.
+impl BundleFetcher {
+    /// Creates a new BundleFetcher from the provided builder config.
+    pub fn new(config: &BuilderConfig) -> Self {
+        Self {
+            config: config.clone(),
+        }
+    }
+
+    /// Fetches bundles from the transaction cache and returns the (oldest? random?) bundle in the cache.
+    pub async fn check_bundle_cache(&mut self) -> Result<Bundle, Error> {
+        let bundle_url: Url = Url::parse(&self.config.tx_pool_url)?.join("bundles")?;
+        let result = reqwest::get(bundle_url).await?;
+        let response: TxPoolBundleResponse = from_slice(result.text().await?.as_bytes())?;
+        match response.bundles.into_iter().next() {
+            Some(bundle) => Ok(bundle),
+            None => Err(eyre::eyre!("no bundles found in tx-pool")),
+        }
+    }
+    
+    pub fn spawn(mut self, bundle_channel: mpsc::UnboundedSender<Bundle>) -> JoinHandle<()> {
+
+        let handle: JoinHandle<()> = tokio::spawn(async move {
+
+            loop {
+
+                let bundle_channel = bundle_channel.clone();
+                let bundles = self.check_bundle_cache().await;
+
+                match bundles {
+                    Ok(bundle) => {
+                        debug!("bundles found in tx-pool");
+                        let result = bundle_channel.send(bundle);
+                        if result.is_err() {
+                            tracing::debug!("bundle_channel failed to send bundle");
+                            continue;
+                        }
+                    },
+                    Err(err) => {
+                        debug!(?err, "no bundles found in tx-pool");
+                    },
+                }
+            }
+
+        });
+
+        handle
+    }
+}

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -2,18 +2,13 @@
 use std::time::Duration;
 
 pub use crate::config::BuilderConfig;
-use alloy_sol_types::abi::token;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
-use serde_json::from_slice;
 use signet_types::SignetEthBundle;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::debug;
 
-use oauth2::{
-    basic::BasicClient, basic::BasicTokenType, reqwest::http_client, AuthUrl, ClientId,
-    ClientSecret, EmptyExtraTokenFields, StandardTokenResponse, TokenResponse, TokenUrl,
-};
+use oauth2::TokenResponse;
 
 use super::oauth::Authenticator;
 

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -1,3 +1,4 @@
+//! Bundler service responsible for polling and submitting bundles to the in-progress block.
 use std::time::Duration;
 
 pub use crate::config::BuilderConfig;

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -1,11 +1,20 @@
+use std::time::Duration;
+
 pub use crate::config::BuilderConfig;
-use eyre::Error;
-use reqwest::{Client, Url};
+use alloy_sol_types::abi::token;
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::from_slice;
 use signet_types::SignetEthBundle;
 use tokio::{sync::mpsc, task::JoinHandle};
-use tracing::{debug, info};
+use tracing::debug;
+
+use oauth2::{
+    basic::BasicClient, basic::BasicTokenType, reqwest::http_client, AuthUrl, ClientId,
+    ClientSecret, EmptyExtraTokenFields, StandardTokenResponse, TokenResponse, TokenUrl,
+};
+
+use super::oauth::Authenticator;
 
 // TODO: Consider exporting this type from the signet-types crate instead of duplicating it here.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,54 +29,68 @@ pub struct TxPoolBundleResponse {
     pub bundles: Vec<Bundle>,
 }
 
-pub struct BundleFetcher {
+pub struct BundlePoller {
     pub config: BuilderConfig,
+    pub authenticator: Authenticator,
 }
 
 /// Implements a poller for the block builder to pull bundles from the tx cache.
-impl BundleFetcher {
-    /// Creates a new BundleFetcher from the provided builder config.
-    pub fn new(config: &BuilderConfig) -> Self {
+impl BundlePoller {
+    /// Creates a new BundlePoller from the provided builder config.
+    pub async fn new(config: &BuilderConfig, authenticator: Authenticator) -> Self {
         Self {
             config: config.clone(),
+            authenticator,
         }
     }
 
     /// Fetches bundles from the transaction cache and returns the (oldest? random?) bundle in the cache.
-    pub async fn check_bundle_cache(&mut self) -> Result<Bundle, Error> {
-        let bundle_url: Url = Url::parse(&self.config.tx_pool_url)?.join("bundles")?;
-        let result = reqwest::get(bundle_url).await?;
-        let response: TxPoolBundleResponse = from_slice(result.text().await?.as_bytes())?;
-        match response.bundles.into_iter().next() {
-            Some(bundle) => Ok(bundle),
-            None => Err(eyre::eyre!("no bundles found in tx-pool")),
+    pub async fn check_bundle_cache(&mut self) -> eyre::Result<Option<Bundle>> {
+        // Fetch a token from the authenticator if not currently authenticated
+        if !self.authenticator.is_authenticated().await {
+            self.authenticator.authenticate().await?;
         }
+
+        let bundle_url: Url = Url::parse(&self.config.tx_pool_url)?.join("bundles")?;
+        let token = self.authenticator.token().await?;
+
+        // Add the token to the request headers
+        let result = reqwest::Client::new()
+            .get(bundle_url)
+            .bearer_auth(token.access_token().secret())
+            .send()
+            .await?
+            .error_for_status()?;
+
+        let body = result.bytes().await?;
+        tracing::debug!(bytes = body.len(), "retrieved response body");
+        tracing::trace!(body = %String::from_utf8_lossy(&body), "response body");
+        serde_json::from_slice(&body).map_err(Into::into)
     }
-    
+
     pub fn spawn(mut self, bundle_channel: mpsc::UnboundedSender<Bundle>) -> JoinHandle<()> {
-
         let handle: JoinHandle<()> = tokio::spawn(async move {
-
             loop {
-
                 let bundle_channel = bundle_channel.clone();
                 let bundles = self.check_bundle_cache().await;
 
                 match bundles {
-                    Ok(bundle) => {
-                        debug!("bundles found in tx-pool");
+                    Ok(Some(bundle)) => {
                         let result = bundle_channel.send(bundle);
                         if result.is_err() {
                             tracing::debug!("bundle_channel failed to send bundle");
-                            continue;
                         }
-                    },
+                    }
+                    Ok(None) => {
+                        debug!("no bundles found in tx-pool");
+                    }
                     Err(err) => {
-                        debug!(?err, "no bundles found in tx-pool");
-                    },
+                        debug!(?err, "error fetching bundles from tx-pool");
+                    }
                 }
-            }
 
+                tokio::time::sleep(Duration::from_secs(self.config.tx_pool_poll_interval)).await;
+            }
         });
 
         handle

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -42,13 +42,8 @@ impl BundlePoller {
 
     /// Fetches bundles from the transaction cache and returns the (oldest? random?) bundle in the cache.
     pub async fn check_bundle_cache(&mut self) -> eyre::Result<Option<Bundle>> {
-        // Fetch a token from the authenticator if not currently authenticated
-        if !self.authenticator.is_authenticated().await {
-            self.authenticator.authenticate().await?;
-        }
-
         let bundle_url: Url = Url::parse(&self.config.tx_pool_url)?.join("bundles")?;
-        let token = self.authenticator.token().await?;
+        let token = self.authenticator.fetch_oauth_token().await?;
 
         // Add the token to the request headers
         let result = reqwest::Client::new()

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,5 +1,5 @@
 pub mod block;
-pub mod submit;
-pub mod tx_poller;
 pub mod bundler;
 pub mod oauth;
+pub mod submit;
+pub mod tx_poller;

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,3 +1,4 @@
 pub mod block;
 pub mod submit;
 pub mod tx_poller;
+pub mod bundler;

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -2,3 +2,4 @@ pub mod block;
 pub mod submit;
 pub mod tx_poller;
 pub mod bundler;
+pub mod oauth;

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -85,8 +85,6 @@ impl Authenticator {
 }
 
 mod tests {
-    use super::*;
-
     use crate::{config::BuilderConfig, tasks::block::BlockBuilder};
     use alloy_primitives::Address;
     use eyre::Result;
@@ -94,16 +92,20 @@ mod tests {
     #[ignore = "integration test"]
     #[tokio::test]
     async fn test_authenticator() -> Result<()> {
+        use super::*;
+        use oauth2::TokenResponse;
+
         let config = setup_test_builder()?.1;
         let auth = Authenticator::new(&config).await?;
         let token = auth.fetch_oauth_token().await?;
         dbg!(&token);
-        // let token = auth.token().await?;
-        // println!("{:?}", token);
-        // assert!(token.access_token().secret().len() > 0);
+        let token = auth.token().await?;
+        println!("{:?}", token);
+        assert!(!token.access_token().secret().is_empty());
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn setup_test_builder() -> Result<(BlockBuilder, BuilderConfig)> {
         let config = BuilderConfig {
             host_chain_id: 17000,

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -1,14 +1,10 @@
-//! OAuth service responsible for authenticating with the cache.
-use std::sync::Arc;
-
+//! Service responsible for authenticating with the cache with Oauth tokens.
 use crate::config::BuilderConfig;
-use eyre::eyre;
 use oauth2::{
     basic::{BasicClient, BasicTokenType},
     reqwest::http_client,
     AuthUrl, ClientId, ClientSecret, EmptyExtraTokenFields, StandardTokenResponse, TokenUrl,
 };
-use reqwest::Url;
 use tokio::task;
 
 const OAUTH_AUDIENCE_CLAIM: &str = "audience";
@@ -127,8 +123,8 @@ mod tests {
             tx_pool_poll_interval: 5,
             oauth_client_id: "some_client_id".into(),
             oauth_client_secret: "some_client_secret".into(),
-            oauth_authenticate_url: "http://localhost:8080".into(),
-            oauth_token_url: "http://localhost:8080".into(),
+            oauth_authenticate_url: "http://localhost:9000".into(),
+            oauth_token_url: "http://localhost:9000".into(),
             oauth_audience: "https://transactions.holesky.signet.sh".into(),
             tx_broadcast_urls: vec!["http://localhost:9000".into()],
         };

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -28,18 +28,17 @@ impl Authenticator {
     pub async fn authenticate(&mut self) -> eyre::Result<()> {
         let token = self.fetch_oauth_token().await?;
         dbg!(&token);
-        // self.set_token(token).await;
+        self.set_token(token);
         Ok(())
     }
 
     /// Returns true if there is Some token set
     pub async fn is_authenticated(&self) -> bool {
-        // TODO: Consider checking if the token is still valid and fetching a new one if it's not
         self.token.is_some()
     }
 
     /// Sets the Authenticator's token to the provided value
-    pub async fn set_token(
+    pub fn set_token(
         &mut self,
         token: StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
     ) {

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -1,20 +1,46 @@
 //! Service responsible for authenticating with the cache with Oauth tokens.
+//! This authenticator periodically fetches a new token every set amount of seconds.
+use std::sync::Arc;
+
 use crate::config::BuilderConfig;
 use oauth2::{
     basic::{BasicClient, BasicTokenType},
     reqwest::http_client,
     AuthUrl, ClientId, ClientSecret, EmptyExtraTokenFields, StandardTokenResponse, TokenUrl,
 };
+use tokio::{sync::RwLock, task::JoinHandle};
 
 const OAUTH_AUDIENCE_CLAIM: &str = "audience";
 
 type Token = StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>;
 
-/// Holds a reference to the current oauth token and the builder config
+/// A self-refreshing, periodically fetching authenticator for the block builder.
+/// It is architected as a shareable struct that can be used across all the multiple builder tasks.
+/// It fetches a new token every set amount of seconds, configured through the general builder config.
+/// Readers are guaranteed to not read stale tokens as the [RwLock] guarantees that write tasks (refreshing the token) will claim priority over read access.
 #[derive(Debug, Clone)]
 pub struct Authenticator {
     pub config: BuilderConfig,
+    inner: Arc<RwLock<AuthenticatorInner>>,
+}
+
+/// Inner state of the Authenticator.
+/// Contains the token that is being used for authentication.
+#[derive(Debug)]
+pub struct AuthenticatorInner {
     pub token: Option<Token>,
+}
+
+impl Default for AuthenticatorInner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AuthenticatorInner {
+    pub fn new() -> Self {
+        Self { token: None }
+    }
 }
 
 impl Authenticator {
@@ -22,34 +48,37 @@ impl Authenticator {
     pub fn new(config: &BuilderConfig) -> Self {
         Self {
             config: config.clone(),
-            token: None,
+            inner: Arc::new(RwLock::new(AuthenticatorInner::new())),
         }
     }
 
     /// Requests a new authentication token and, if successful, sets it to as the token
-    pub async fn authenticate(&mut self) -> eyre::Result<()> {
+    pub async fn authenticate(&self) -> eyre::Result<()> {
         let token = self.fetch_oauth_token().await?;
-        dbg!(&token);
-        self.set_token(token);
+        self.set_token(token).await;
         Ok(())
     }
 
     /// Returns true if there is Some token set
-    pub fn is_authenticated(&self) -> bool {
-        self.token.is_some()
+    pub async fn is_authenticated(&self) -> bool {
+        let lock = self.inner.read().await;
+
+        lock.token.is_some()
     }
 
     /// Sets the Authenticator's token to the provided value
-    pub fn set_token(
-        &mut self,
+    pub async fn set_token(
+        &self,
         token: StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
     ) {
-        self.token = Some(token);
+        let mut lock = self.inner.write().await;
+        lock.token = Some(token);
     }
 
     /// Returns the currently set token
-    pub fn token(&self) -> Option<Token> {
-        self.token.clone()
+    pub async fn token(&self) -> Option<Token> {
+        let lock = self.inner.read().await;
+        lock.token.clone()
     }
 
     /// Fetches an oauth token
@@ -57,13 +86,12 @@ impl Authenticator {
         &self,
     ) -> eyre::Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>> {
         let config = self.config.clone();
-        dbg!(config.clone());
 
         let client = BasicClient::new(
-            ClientId::new(self.config.oauth_client_id.clone()),
-            Some(ClientSecret::new(self.config.oauth_client_secret.clone())),
-            AuthUrl::new(self.config.oauth_authenticate_url.clone())?,
-            Some(TokenUrl::new(self.config.oauth_token_url.clone())?),
+            ClientId::new(config.oauth_client_id.clone()),
+            Some(ClientSecret::new(config.oauth_client_secret.clone())),
+            AuthUrl::new(config.oauth_authenticate_url.clone())?,
+            Some(TokenUrl::new(config.oauth_token_url.clone())?),
         );
 
         let token_result = client
@@ -72,6 +100,19 @@ impl Authenticator {
             .request(http_client)?;
 
         Ok(token_result)
+    }
+
+    /// Spawns a task that periodically fetches a new token every 300 seconds.
+    pub async fn spawn(self) -> JoinHandle<()> {
+        let interval = self.config.oauth_token_refresh_interval;
+
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
+                tracing::info!("Refreshing oauth token");
+                self.authenticate().await.unwrap();
+            }
+        })
     }
 }
 
@@ -90,7 +131,7 @@ mod tests {
         let auth = Authenticator::new(&config);
         let token = auth.fetch_oauth_token().await?;
         dbg!(&token);
-        let token = auth.token().unwrap();
+        let token = auth.token().await.unwrap();
         println!("{:?}", token);
         assert!(!token.access_token().secret().is_empty());
         Ok(())
@@ -120,6 +161,7 @@ mod tests {
             oauth_token_url: "http://localhost:9000".into(),
             oauth_audience: "https://transactions.holesky.signet.sh".into(),
             tx_broadcast_urls: vec!["http://localhost:9000".into()],
+            oauth_token_refresh_interval: 300, // 5 minutes
         };
         Ok((BlockBuilder::new(&config), config))
     }

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -5,7 +5,6 @@ use oauth2::{
     reqwest::http_client,
     AuthUrl, ClientId, ClientSecret, EmptyExtraTokenFields, StandardTokenResponse, TokenUrl,
 };
-use tokio::task;
 
 const OAUTH_AUDIENCE_CLAIM: &str = "audience";
 
@@ -71,14 +70,10 @@ impl Authenticator {
             Some(TokenUrl::new(self.config.oauth_token_url.clone())?),
         );
 
-        // Use spawn_blocking to handle the blocking client request.
-        let token_result = task::spawn_blocking(move || {
-            client
-                .exchange_client_credentials()
-                .add_extra_param(OAUTH_AUDIENCE_CLAIM, config.oauth_audience.clone())
-                .request(http_client)
-        })
-        .await??; // Handle errors from spawn_blocking and the OAuth request.
+        let token_result = client
+            .exchange_client_credentials()
+            .add_extra_param(OAUTH_AUDIENCE_CLAIM, config.oauth_audience.clone())
+            .request(http_client)?;
 
         Ok(token_result)
     }

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -1,0 +1,124 @@
+use crate::config::BuilderConfig;
+use oauth2::{
+    basic::{BasicClient, BasicTokenType},
+    reqwest::http_client,
+    AuthUrl, ClientId, ClientSecret, EmptyExtraTokenFields, StandardTokenResponse, TokenUrl,
+};
+
+const OAUTH_AUDIENCE_CLAIM: &str = "audience";
+
+/// Holds a reference to the current oauth token and the builder config
+#[derive(Debug, Clone)]
+pub struct Authenticator {
+    pub config: BuilderConfig,
+    pub token: Option<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>>,
+}
+
+impl Authenticator {
+    /// Creates a new Authenticator from the provided builder config.
+    pub async fn new(config: &BuilderConfig) -> eyre::Result<Self> {
+        Ok(Self {
+            config: config.clone(),
+            token: None,
+        })
+    }
+
+    /// Requests a new authentication token and, if successful, sets it to as the token
+    pub async fn authenticate(&mut self) -> eyre::Result<()> {
+        let token = self.fetch_oauth_token()?;
+        dbg!(&token);
+        // self.set_token(token).await;
+        Ok(())
+    }
+
+    /// Returns true if there is Some token set
+    pub async fn is_authenticated(&self) -> bool {
+        // TODO: Consider checking if the token is still valid and fetching a new one if it's not
+        self.token.is_some()
+    }
+
+    /// Sets the Authenticator's token to the provided value
+    pub async fn set_token(
+        &mut self,
+        token: StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
+    ) {
+        self.token = Some(token);
+    }
+
+    /// Returns the currently set token
+    pub async fn token(
+        &self,
+    ) -> eyre::Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>> {
+        self.token
+            .as_ref()
+            .ok_or(eyre::eyre!("no token set"))
+            .cloned()
+    }
+
+    /// Fetches an oauth token and saves it to the Authenticator
+    /// Does not set a new token, it only requests a new one
+    pub fn fetch_oauth_token(
+        &self,
+    ) -> eyre::Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>> {
+        let client = BasicClient::new(
+            ClientId::new(self.config.oauth_client_id.clone()),
+            Some(ClientSecret::new(self.config.oauth_client_secret.clone())),
+            AuthUrl::new(self.config.oauth_authenticate_url.clone())?,
+            Some(TokenUrl::new(self.config.oauth_token_url.clone())?),
+        );
+
+        let token_result = client
+            .exchange_client_credentials()
+            .add_extra_param(OAUTH_AUDIENCE_CLAIM, self.config.oauth_audience.clone())
+            .request(http_client)?;
+
+        Ok(token_result)
+    }
+}
+
+mod tests {
+    use super::*;
+
+    use crate::{config::BuilderConfig, tasks::block::BlockBuilder};
+    use alloy_primitives::Address;
+    use eyre::Result;
+
+    #[tokio::test]
+    async fn test_authenticator() -> Result<()> {
+        let config = setup_test_builder()?.1;
+        let auth = Authenticator::new(&config).await?;
+        let token = auth.fetch_oauth_token()?;
+        dbg!(&token);
+        // let token = auth.token().await?;
+        // println!("{:?}", token);
+        // assert!(token.access_token().secret().len() > 0);
+        Ok(())
+    }
+
+    pub fn setup_test_builder() -> Result<(BlockBuilder, BuilderConfig)> {
+        let config = BuilderConfig {
+            host_chain_id: 17000,
+            ru_chain_id: 17001,
+            host_rpc_url: "http://rpc.holesky.signet.sh".into(),
+            zenith_address: Address::default(),
+            quincey_url: "http://localhost:8080".into(),
+            builder_port: 8080,
+            sequencer_key: None,
+            builder_key: "0000000000000000000000000000000000000000000000000000000000000000".into(),
+            incoming_transactions_buffer: 1,
+            block_confirmation_buffer: 1,
+            builder_rewards_address: Address::default(),
+            rollup_block_gas_limit: 100_000,
+            tx_pool_url: "http://localhost:9000/".into(),
+            tx_pool_cache_duration: 5,
+            tx_pool_poll_interval: 5,
+            oauth_client_id: "some_client_id".into(),
+            oauth_client_secret: "some_client_secret".into(),
+            oauth_authenticate_url: "http://localhost:8080".into(),
+            oauth_token_url: "http://localhost:8080".into(),
+            oauth_audience: "https://transactions.holesky.signet.sh".into(),
+            tx_broadcast_urls: vec!["http://localhost:9000".into()],
+        };
+        Ok((BlockBuilder::new(&config), config))
+    }
+}

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -115,7 +115,7 @@ impl SubmitTask {
         Ok(token_result)
     }
 
-    /// Constructs the signing request from the in-progress block passed to it and assigns the 
+    /// Constructs the signing request from the in-progress block passed to it and assigns the
     /// correct height, chain ID, gas limit, and rollup reward address.
     #[instrument(skip_all)]
     async fn construct_sig_request(&self, contents: &InProgressBlock) -> eyre::Result<SignRequest> {

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -1,12 +1,15 @@
 mod tests {
-    
+
     use alloy_primitives::Address;
-    use builder::{config::BuilderConfig, tasks::{block::BlockBuilder, oauth::Authenticator}};
+    use builder::{
+        config::BuilderConfig,
+        tasks::{block::BlockBuilder, oauth::Authenticator},
+    };
     use eyre::Result;
-    
+
     #[tokio::test]
     async fn test_bundle_poller_roundtrip() -> Result<()> {
-        let (_, config)  = setup_test_builder().await.unwrap();
+        let (_, config) = setup_test_builder().await.unwrap();
         let auth = Authenticator::new(&config).await?;
         let mut bundle_poller = builder::tasks::bundler::BundlePoller::new(&config, auth).await;
 
@@ -16,7 +19,7 @@ mod tests {
         Ok(())
     }
 
-   // TODO: Deduplicate this with the same function in tx_poller_test.rs
+    // TODO: Deduplicate this with the same function in tx_poller_test.rs
     async fn setup_test_builder() -> Result<(BlockBuilder, BuilderConfig)> {
         let config = BuilderConfig {
             host_chain_id: 17000,

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -19,7 +19,6 @@ mod tests {
         Ok(())
     }
 
-    // TODO: Deduplicate this with the same function in tx_poller_test.rs
     async fn setup_test_builder() -> Result<(BlockBuilder, BuilderConfig)> {
         let config = BuilderConfig {
             host_chain_id: 17000,

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -43,6 +43,7 @@ mod tests {
             oauth_token_url: "http://localhost:8080".into(),
             oauth_audience: "https://transactions.holesky.signet.sh".into(),
             tx_broadcast_urls: vec!["http://localhost:9000".into()],
+            oauth_token_refresh_interval: 300, // 5 minutes
         };
         Ok((BlockBuilder::new(&config), config))
     }

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -40,6 +40,7 @@ mod tests {
             oauth_authenticate_url: "http://localhost:8080".into(),
             oauth_token_url: "http://localhost:8080".into(),
             oauth_audience: "https://transactions.holesky.signet.sh".into(),
+            tx_broadcast_urls: vec!["http://localhost:9000".into()],
         };
         Ok((BlockBuilder::new(&config), config))
     }

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -1,5 +1,4 @@
 mod tests {
-
     use alloy_primitives::Address;
     use builder::{
         config::BuilderConfig,
@@ -7,6 +6,7 @@ mod tests {
     };
     use eyre::Result;
 
+    #[ignore = "integration test"]
     #[tokio::test]
     async fn test_bundle_poller_roundtrip() -> Result<()> {
         let (_, config) = setup_test_builder().await.unwrap();

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -10,7 +10,7 @@ mod tests {
     #[tokio::test]
     async fn test_bundle_poller_roundtrip() -> Result<()> {
         let (_, config) = setup_test_builder().await.unwrap();
-        let auth = Authenticator::new(&config).await?;
+        let auth = Authenticator::new(&config);
         let mut bundle_poller = builder::tasks::bundler::BundlePoller::new(&config, auth).await;
 
         let got = bundle_poller.check_bundle_cache().await?;

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -1,0 +1,46 @@
+mod tests {
+    
+    use alloy_primitives::Address;
+    use builder::{config::BuilderConfig, tasks::{block::BlockBuilder, oauth::Authenticator}};
+    use eyre::Result;
+    
+    #[tokio::test]
+    async fn test_bundle_poller_roundtrip() -> Result<()> {
+        let (_, config)  = setup_test_builder().await.unwrap();
+        let auth = Authenticator::new(&config).await?;
+        let mut bundle_poller = builder::tasks::bundler::BundlePoller::new(&config, auth).await;
+
+        let got = bundle_poller.check_bundle_cache().await?;
+        dbg!(got);
+
+        Ok(())
+    }
+
+   // TODO: Deduplicate this with the same function in tx_poller_test.rs
+    async fn setup_test_builder() -> Result<(BlockBuilder, BuilderConfig)> {
+        let config = BuilderConfig {
+            host_chain_id: 17000,
+            ru_chain_id: 17001,
+            host_rpc_url: "http://rpc.holesky.signet.sh".into(),
+            zenith_address: Address::default(),
+            quincey_url: "http://localhost:8080".into(),
+            builder_port: 8080,
+            sequencer_key: None,
+            builder_key: "0000000000000000000000000000000000000000000000000000000000000000".into(),
+            incoming_transactions_buffer: 1,
+            block_confirmation_buffer: 1,
+            builder_rewards_address: Address::default(),
+            rollup_block_gas_limit: 100_000,
+            tx_pool_url: "http://localhost:9000/".into(),
+            // tx_pool_url: "https://transactions.holesky.signet.sh".into(),
+            tx_pool_cache_duration: 5,
+            tx_pool_poll_interval: 5,
+            oauth_client_id: "some_client_id".into(),
+            oauth_client_secret: "some_client_secret".into(),
+            oauth_authenticate_url: "http://localhost:8080".into(),
+            oauth_token_url: "http://localhost:8080".into(),
+            oauth_audience: "https://transactions.holesky.signet.sh".into(),
+        };
+        Ok((BlockBuilder::new(&config), config))
+    }
+}

--- a/tests/tx_poller_test.rs
+++ b/tests/tx_poller_test.rs
@@ -86,6 +86,7 @@ mod tests {
             oauth_authenticate_url: "http://localhost:8080".into(),
             oauth_token_url: "http://localhost:8080".into(),
             oauth_audience: "https://transactions.holesky.signet.sh".into(),
+            oauth_token_refresh_interval: 300, // 5 minutes
         };
         Ok((BlockBuilder::new(&config), config))
     }

--- a/tests/tx_poller_test.rs
+++ b/tests/tx_poller_test.rs
@@ -6,7 +6,7 @@ mod tests {
     use alloy_primitives::{bytes, Address, TxKind, U256};
     use builder::config::BuilderConfig;
     use builder::tasks::{block::BlockBuilder, tx_poller};
-    use eyre::Result;
+    use eyre::{Ok, Result};
 
     #[ignore = "integration test"]
     #[tokio::test]
@@ -21,7 +21,7 @@ mod tests {
         let mut poller = tx_poller::TxPoller::new(&config);
 
         // Fetch transactions the pool
-        let transactions = poller.check_tx_pool().await?;
+        let transactions = poller.check_tx_cache().await?;
 
         // Ensure at least one transaction exists
         assert!(!transactions.is_empty());

--- a/tests/tx_poller_test.rs
+++ b/tests/tx_poller_test.rs
@@ -63,7 +63,7 @@ mod tests {
     }
 
     // Sets up a block builder with test values
-    async fn setup_test_builder() -> Result<(BlockBuilder, BuilderConfig)> {
+    pub async fn setup_test_builder() -> Result<(BlockBuilder, BuilderConfig)> {
         let config = BuilderConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,


### PR DESCRIPTION
This PR adds a `BundleFetcher` that the block builder uses to fetch bundles from the tx cache. It works similarly to the tx poller:
- it requests all bundles from the cache
- it filters out the already seen ones, keeping only the unique bundles
- it then sends these to the block task, which ingests the bundles one by one.
  - When ingesting the bundles, right now only the txs are ingested, without respecting the set configurations for bundles, nor including the permit2 signed orders. This means that only the basic bundle functionality is implemented. Further implementation probably requires simulation work.
  - There's no specific rule to where the txs of the bundle land in the block. We are simply extending the block with the new transactions.

Closes ENG-630.

DO NOT MERGE until ENG-633 is implemented.