### PR TITLE
fix: this time, but with gusto

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -22,6 +22,8 @@ jobs:
                 fetch-tags: "true"
                 fetch-depth: "0"
             - name: Verify new release needed
+              env:
+                GH_TOKEN: ${{ github.token }}
               run: |
                 echo "Checking if a new release is needed"
                 # get current version from cargo


### PR DESCRIPTION
### TL;DR
Added GitHub token environment variable to release verification step

### What changed?
Added `GH_TOKEN` environment variable using the default GitHub token in the autorelease workflow's verification step
