### PR TITLE
feat: use shared autorelease workflow

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,44 +1,17 @@
-name: Tag New Release
+name: Create Rust Release
+
 on:
-    push:
-      branches:
-        - main
-      paths:
-        - 'Cargo.toml'
-  
-permissions:
-    contents: write
-    id-token: write
+  push:
+    branches:
+    - main
+    paths:
+    - 'Cargo.toml'
+
+permissions: # these permissions are required for the actions to run
+  contents: write
 
 jobs:
-    verify-new-release-needed:
-        name: Verify new release needed
-        runs-on: ubuntu-latest
-        environment: dev
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-              with: 
-                fetch-tags: "true"
-                fetch-depth: "0"
-            - name: Verify new release needed
-              env:
-                GH_TOKEN: ${{ github.token }}
-              run: |
-                echo "Checking if a new release is needed"
-                # get current version from cargo
-                CARGO_VER="v$(cargo metadata --format-version=1 --no-deps  | jq '.packages[] | select(.name == "zenith-builder-example") | .version' -r)"
-                echo "$CARGO_VER"
-                # get latest version from git tags
-                GIT_VER=$(git describe --tags $(git rev-list --tags --max-count=1))
-                echo "$GIT_VER"
-                if [ "$CARGO_VER" == "$GIT_VER" ]; then
-                echo "# No new release needed" >> $GITHUB_STEP_SUMMARY
-                exit 0
-                else
-                    echo "New release needed"
-                    gh release create "$CARGO_VER" -t "$CARGO_VER" --generate-notes
-                    ## Add the release information to the github actions summary
-                    echo "# New Release Created" >> $GITHUB_STEP_SUMMARY
-                    echo "Tag: $CARGO_VER" >> $GITHUB_STEP_SUMMARY
-                fi
+  auto-release: 
+    uses: init4tech/actions/.github/workflows/auto-release-rust.yml@main
+    with:
+      binary-name: 'zenith-builder-example'


### PR DESCRIPTION
### TL;DR
Simplified the auto-release workflow by utilizing a reusable workflow from init4tech/actions.

### What changed?
Replaced the custom release verification and creation logic with a standardized reusable workflow. The new workflow maintains the same trigger conditions (pushing to main branch with changes to Cargo.toml) while reducing complexity.

### How to test?
1. Update the version in Cargo.toml
2. Push changes to the main branch
3. Verify that a new release is automatically created with the updated version