### PR TITLE
chore(authenticator): fix authenticator task being dropped

### DIFF
--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -100,7 +100,7 @@ impl Authenticator {
     }
 
     /// Spawns a task that periodically fetches a new token every 300 seconds.
-    pub async fn spawn(self) -> JoinHandle<()> {
+    pub fn spawn(self) -> JoinHandle<()> {
         let interval = self.config.oauth_token_refresh_interval;
 
         let handle: JoinHandle<()> = tokio::spawn(async move {


### PR DESCRIPTION
The `select!` block was returning early because the `spawn` fn of the `authenticator` task was a future being awaited, instead of just returning the join handle.