### PR TITLE
feat: filter confirmed transactions from the block

### DIFF
--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -14,18 +14,19 @@ async fn main() -> eyre::Result<()> {
     let span = tracing::info_span!("zenith-builder");
 
     let config = BuilderConfig::load_from_env()?.clone();
-    let provider = config.connect_provider().await?;
+    let host_provider = config.connect_host_provider().await?;
+    let ru_provider = config.connect_ru_provider().await?;
     let authenticator = Authenticator::new(&config);
 
     tracing::debug!(rpc_url = config.host_rpc_url.as_ref(), "instantiated provider");
 
     let sequencer_signer = config.connect_sequencer_signer().await?;
-    let zenith = config.connect_zenith(provider.clone());
+    let zenith = config.connect_zenith(host_provider.clone());
 
-    let builder = BlockBuilder::new(&config, authenticator.clone());
+    let builder = BlockBuilder::new(&config, authenticator.clone(), ru_provider);
     let submit = SubmitTask {
         authenticator: authenticator.clone(),
-        provider,
+        host_provider,
         zenith,
         client: reqwest::Client::new(),
         sequencer_signer,

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,7 +195,7 @@ impl BuilderConfig {
         }
     }
 
-    /// Connect to rollup rpc provider.
+    /// Connect to the Rollup rpc provider.
     pub async fn connect_ru_provider(&self) -> Result<WalletlessProvider, ConfigError> {
         ProviderBuilder::new()
             .with_recommended_fillers()
@@ -204,7 +204,7 @@ impl BuilderConfig {
             .map_err(Into::into)
     }
 
-    /// Connect to an rpc provider.
+    /// Connect to the Host rpc provider.
     pub async fn connect_host_provider(&self) -> Result<Provider, ConfigError> {
         let builder_signer = self.connect_builder_signer().await?;
         ProviderBuilder::new()

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,7 +199,7 @@ impl BuilderConfig {
     pub async fn connect_ru_provider(&self) -> Result<WalletlessProvider, ConfigError> {
         ProviderBuilder::new()
             .with_recommended_fillers()
-            .on_builtin(&self.ru_rpc_url.clone())
+            .on_builtin(&self.ru_rpc_url)
             .await
             .map_err(Into::into)
     }
@@ -210,7 +210,7 @@ impl BuilderConfig {
         ProviderBuilder::new()
             .with_recommended_fillers()
             .wallet(EthereumWallet::from(builder_signer))
-            .on_builtin(&self.host_rpc_url.clone())
+            .on_builtin(&self.host_rpc_url)
             .await
             .map_err(Into::into)
     }

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -186,6 +186,8 @@ impl BlockBuilder {
                 confirmed_transactions.push(transaction.clone());
             }
         }
+        tracing::info!(confirmed = confirmed_transactions.len(), "found confirmed transactions");
+
         // remove already-confirmed transactions
         for transaction in confirmed_transactions {
             in_progress.remove_tx(&transaction);

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -1,8 +1,8 @@
 use super::bundler::{Bundle, BundlePoller};
 use super::oauth::Authenticator;
 use super::tx_poller::TxPoller;
-use crate::config::{BuilderConfig, Provider};
-use alloy::providers::Provider as _;
+use crate::config::{BuilderConfig, WalletlessProvider};
+use alloy::providers::Provider;
 use alloy::{
     consensus::{SidecarBuilder, SidecarCoder, TxEnvelope},
     eips::eip2718::Decodable2718,
@@ -119,7 +119,7 @@ impl InProgressBlock {
 /// BlockBuilder is a task that periodically builds a block then sends it for signing and submission.
 pub struct BlockBuilder {
     pub config: BuilderConfig,
-    pub ru_provider: Provider,
+    pub ru_provider: WalletlessProvider,
     pub tx_poller: TxPoller,
     pub bundle_poller: BundlePoller,
 }
@@ -129,7 +129,7 @@ impl BlockBuilder {
     pub fn new(
         config: &BuilderConfig,
         authenticator: Authenticator,
-        ru_provider: Provider,
+        ru_provider: WalletlessProvider,
     ) -> Self {
         Self {
             config: config.clone(),

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -173,7 +173,7 @@ impl BlockBuilder {
         self.bundle_poller.evict();
     }
 
-    async fn filter_transactions(&mut self, in_progress: &mut InProgressBlock) {
+    async fn filter_transactions(&self, in_progress: &mut InProgressBlock) {
         // query the rollup node to see which transaction(s) have been included
         let mut confirmed_transactions = Vec::new();
         for transaction in in_progress.transactions.iter() {
@@ -195,14 +195,14 @@ impl BlockBuilder {
     }
 
     // calculate the duration in seconds until the beginning of the next block slot.
-    fn secs_to_next_slot(&mut self) -> u64 {
+    fn secs_to_next_slot(&self) -> u64 {
         let curr_timestamp: u64 = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
         let current_slot_time = (curr_timestamp - self.config.chain_offset) % ETHEREUM_SLOT_TIME;
         (ETHEREUM_SLOT_TIME - current_slot_time) % ETHEREUM_SLOT_TIME
     }
 
     // add a buffer to the beginning of the block slot.
-    fn secs_to_next_target(&mut self) -> u64 {
+    fn secs_to_next_target(&self) -> u64 {
         self.secs_to_next_slot() + self.config.target_slot_time
     }
 

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -1,8 +1,8 @@
 use super::bundler::{Bundle, BundlePoller};
 use super::oauth::Authenticator;
 use super::tx_poller::TxPoller;
-use crate::config::BuilderConfig;
-use alloy::providers::Provider;
+use crate::config::{BuilderConfig, Provider};
+use alloy::providers::Provider as _;
 use alloy::{
     consensus::{SidecarBuilder, SidecarCoder, TxEnvelope},
     eips::eip2718::Decodable2718,
@@ -119,7 +119,7 @@ impl InProgressBlock {
 /// BlockBuilder is a task that periodically builds a block then sends it for signing and submission.
 pub struct BlockBuilder {
     pub config: BuilderConfig,
-    pub ru_provider: crate::config::Provider,
+    pub ru_provider: Provider,
     pub tx_poller: TxPoller,
     pub bundle_poller: BundlePoller,
 }
@@ -129,7 +129,7 @@ impl BlockBuilder {
     pub fn new(
         config: &BuilderConfig,
         authenticator: Authenticator,
-        ru_provider: crate::config::Provider,
+        ru_provider: Provider,
     ) -> Self {
         Self {
             config: config.clone(),

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -148,8 +148,8 @@ mod tests {
         let config = BuilderConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,
-            host_rpc_url: "https://ethereum-holesky-rpc.publicnode.com".into(),
-            ru_rpc_url: "http://rpc.holesky.signet.sh".into(),
+            host_rpc_url: "host-rpc.example.com".into(),
+            ru_rpc_url: "ru-rpc.example.com".into(),
             zenith_address: Address::default(),
             quincey_url: "http://localhost:8080".into(),
             builder_port: 8080,

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -148,7 +148,8 @@ mod tests {
         let config = BuilderConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,
-            host_rpc_url: "http://rpc.holesky.signet.sh".into(),
+            host_rpc_url: "https://ethereum-holesky-rpc.publicnode.com".into(),
+            ru_rpc_url: "http://rpc.holesky.signet.sh".into(),
             zenith_address: Address::default(),
             quincey_url: "http://localhost:8080".into(),
             builder_port: 8080,

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -50,7 +50,7 @@ pub enum ControlFlow {
 /// Submits sidecars in ethereum txns to mainnet ethereum
 pub struct SubmitTask {
     /// Ethereum Provider
-    pub provider: Provider,
+    pub host_provider: Provider,
     /// Zenith
     pub zenith: ZenithInstance,
     /// Reqwest
@@ -125,7 +125,7 @@ impl SubmitTask {
     }
 
     async fn next_host_block_height(&self) -> eyre::Result<u64> {
-        let result = self.provider.get_block_number().await?;
+        let result = self.host_provider.get_block_number().await?;
         let next = result.checked_add(1).ok_or_else(|| eyre!("next host block height overflow"))?;
         Ok(next)
     }
@@ -150,12 +150,12 @@ impl SubmitTask {
 
         let tx = self
             .build_blob_tx(header, v, r, s, in_progress)?
-            .with_from(self.provider.default_signer_address())
+            .with_from(self.host_provider.default_signer_address())
             .with_to(self.config.zenith_address)
             .with_gas_limit(1_000_000);
 
         if let Err(TransportError::ErrorResp(e)) =
-            self.provider.call(&tx).block(BlockNumberOrTag::Pending.into()).await
+            self.host_provider.call(&tx).block(BlockNumberOrTag::Pending.into()).await
         {
             error!(
                 code = e.code,
@@ -185,16 +185,16 @@ impl SubmitTask {
             "sending transaction to network"
         );
 
-        let SendableTx::Envelope(tx) = self.provider.fill(tx).await? else {
+        let SendableTx::Envelope(tx) = self.host_provider.fill(tx).await? else {
             bail!("failed to fill transaction")
         };
 
-        // Send the tx via the primary provider
-        let fut = spawn_provider_send!(&self.provider, &tx);
+        // Send the tx via the primary host_provider
+        let fut = spawn_provider_send!(&self.host_provider, &tx);
 
-        // Spawn send_tx futures for all additional broadcast providers
-        for provider in self.config.connect_additional_broadcast().await? {
-            spawn_provider_send!(&provider, &tx);
+        // Spawn send_tx futures for all additional broadcast host_providers
+        for host_provider in self.config.connect_additional_broadcast().await? {
+            spawn_provider_send!(&host_provider, &tx);
         }
 
         // question mark unwraps join error, which would be an internal panic

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -20,8 +20,8 @@ mod tests {
         let config = BuilderConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,
-            host_rpc_url: "https://ethereum-holesky-rpc.publicnode.com".into(),
-            ru_rpc_url: "http://rpc.holesky.signet.sh".into(),
+            host_rpc_url: "host-rpc.example.com".into(),
+            ru_rpc_url: "ru-rpc.example.com".into(),
             zenith_address: Address::default(),
             quincey_url: "http://localhost:8080".into(),
             builder_port: 8080,

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -20,7 +20,8 @@ mod tests {
         let config = BuilderConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,
-            host_rpc_url: "http://rpc.holesky.signet.sh".into(),
+            host_rpc_url: "https://ethereum-holesky-rpc.publicnode.com".into(),
+            ru_rpc_url: "http://rpc.holesky.signet.sh".into(),
             zenith_address: Address::default(),
             quincey_url: "http://localhost:8080".into(),
             builder_port: 8080,

--- a/tests/tx_poller_test.rs
+++ b/tests/tx_poller_test.rs
@@ -67,8 +67,8 @@ mod tests {
         let config = BuilderConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,
-            host_rpc_url: "https://ethereum-holesky-rpc.publicnode.com".into(),
-            ru_rpc_url: "http://rpc.holesky.signet.sh".into(),
+            host_rpc_url: "host-rpc.example.com".into(),
+            ru_rpc_url: "ru-rpc.example.com".into(),
             tx_broadcast_urls: vec!["http://localhost:9000".into()],
             zenith_address: Address::default(),
             quincey_url: "http://localhost:8080".into(),

--- a/tests/tx_poller_test.rs
+++ b/tests/tx_poller_test.rs
@@ -67,7 +67,8 @@ mod tests {
         let config = BuilderConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,
-            host_rpc_url: "http://rpc.holesky.signet.sh".into(),
+            host_rpc_url: "https://ethereum-holesky-rpc.publicnode.com".into(),
+            ru_rpc_url: "http://rpc.holesky.signet.sh".into(),
             tx_broadcast_urls: vec!["http://localhost:9000".into()],
             zenith_address: Address::default(),
             quincey_url: "http://localhost:8080".into(),


### PR DESCRIPTION
ensures that transactions which have already confirmed on the rollup are not included in the block

---
does not include removal of the "seen_txns" cache in the TxPoller class. going to make a separate PR for that