### PR TITLE
[spike] Adds bundle helper submission call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,12 @@ name = "transaction-submitter"
 path = "bin/submit_transaction.rs"
 
 [dependencies]
-zenith-types = { git = "https://github.com/init4tech/zenith-rs", tag = "v0.10.1" }
+zenith-types = { path = "../zenith-rs" }
 
-alloy-primitives = { version = "=0.8.8", features = ["serde", "tiny-keccak"] }
-alloy-sol-types = { version = "=0.8.8", features = ["json"] }
+alloy = { version = "0.7.3", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev"] }
+alloy-primitives = { version = "=0.8.16", features = ["serde", "tiny-keccak"] }
+alloy-sol-types = { version = "=0.8.16", features = ["json"] }
 alloy-rlp = { version = "0.3.4" }
-
-alloy = { version = "0.5.4", features = ["full", "json-rpc", "signer-aws"] }
 
 aws-config = "1.1.7"
 aws-sdk-kms = "1.15.0"
@@ -36,8 +35,6 @@ aws-sdk-kms = "1.15.0"
 hex = { package = "const-hex", version = "1", default-features = false, features = [
     "alloc",
 ] }
-
-signet-types = { git = "ssh://git@github.com/init4tech/signet-node.git" }
 
 serde = { version = "1.0.197", features = ["derive"] }
 tracing = "0.1.40"

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,8 +140,7 @@ pub type WalletlessProvider = FillProvider<
     BoxTransport,
     Ethereum,
 >;
-
-pub type ZenithInstance = Zenith::ZenithInstance<BoxTransport, Provider>;
+pub type ZenithInstance = Zenith::ZenithInstance<BoxTransport, Provider, alloy::network::Ethereum>;
 
 impl BuilderConfig {
     /// Load the builder configuration from environment variables.

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -1,20 +1,19 @@
-//! Bundler service responsible for polling and submitting bundles to the in-progress block.
-use std::time::{Duration, Instant};
+//! Bundler service responsible for managing bundles. 
+use super::oauth::Authenticator;
 
 pub use crate::config::BuilderConfig;
-use alloy_primitives::map::HashMap;
+
+use zenith_types::ZenithEthBundle;
+use oauth2::TokenResponse;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
-use signet_types::SignetEthBundle;
-
-use oauth2::TokenResponse;
-
-use super::oauth::Authenticator;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Bundle {
     pub id: String,
-    pub bundle: SignetEthBundle,
+    pub bundle: ZenithEthBundle,
 }
 
 /// Response from the tx-pool containing a list of bundles.


### PR DESCRIPTION
# [WIP] 

### TL;DR

This PR modifies the submit task in the Builder to call the bundle helper contract's submit function. 

### What changed?

- Introduced `FillPermit2` vector for transaction fills
- Replaced `Zenith::BlockHeader` with `BlockHeader` type
- Added `submitCall` structure with fills, header, and signature components
- Modified transaction building to use the bundle helper `submit` function
- Added error handling for transaction submission
