### PR TITLE
chore: bumps alloy and zenith versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,3 @@ async-trait = "0.1.80"
 oauth2 = "4.4.2"
 metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.0"
-
-[dev-dependencies]
-httpmock = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,10 @@ name = "transaction-submitter"
 path = "bin/submit_transaction.rs"
 
 [dependencies]
-zenith-types = { git = "https://github.com/init4tech/zenith-rs", tag = "v0.10.1" }
+zenith-types = "0.13"
 
-alloy-primitives = { version = "=0.8.8", features = ["serde", "tiny-keccak"] }
-alloy-sol-types = { version = "=0.8.8", features = ["json"] }
+alloy = { version = "0.7.3", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev"] }
 alloy-rlp = { version = "0.3.4" }
-
-alloy = { version = "0.5.4", features = ["full", "json-rpc", "signer-aws"] }
 
 aws-config = "1.1.7"
 aws-sdk-kms = "1.15.0"
@@ -36,8 +33,6 @@ aws-sdk-kms = "1.15.0"
 hex = { package = "const-hex", version = "1", default-features = false, features = [
     "alloc",
 ] }
-
-signet-types = { git = "ssh://git@github.com/init4tech/signet-node.git" }
 
 serde = { version = "1.0.197", features = ["derive"] }
 tracing = "0.1.40"
@@ -56,3 +51,6 @@ async-trait = "0.1.80"
 oauth2 = "4.4.2"
 metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.0"
+
+[dev-dependencies]
+httpmock = "0.7.0"

--- a/bin/submit_transaction.rs
+++ b/bin/submit_transaction.rs
@@ -1,10 +1,10 @@
 use alloy::{
     network::{EthereumWallet, TransactionBuilder},
+    primitives::{Address, U256},
     providers::{Provider as _, ProviderBuilder, WalletProvider},
     rpc::types::eth::TransactionRequest,
     signers::aws::AwsSigner,
 };
-use alloy_primitives::Address;
 use aws_config::BehaviorVersion;
 use builder::config::{load_address, load_string, load_u64, load_url, Provider};
 use metrics::counter;
@@ -37,7 +37,7 @@ async fn send_transaction(provider: Provider, recipient_address: Address) {
     let tx = TransactionRequest::default()
         .with_from(provider.default_signer_address())
         .with_to(recipient_address)
-        .with_value(alloy_primitives::U256::from(1))
+        .with_value(U256::from(1))
         .with_gas_limit(30_000);
 
     // start timer to measure how long it takes to mine the transaction

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,12 @@
 use crate::signer::{LocalOrAws, SignerError};
 use alloy::network::{Ethereum, EthereumWallet};
+use alloy::primitives::Address;
 use alloy::providers::fillers::BlobGasFiller;
 use alloy::providers::{
     fillers::{ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller},
     Identity, ProviderBuilder, RootProvider,
 };
 use alloy::transports::BoxTransport;
-use alloy_primitives::Address;
 use std::{borrow::Cow, env, num, str::FromStr};
 use zenith_types::Zenith;
 
@@ -140,8 +140,7 @@ pub type WalletlessProvider = FillProvider<
     BoxTransport,
     Ethereum,
 >;
-
-pub type ZenithInstance = Zenith::ZenithInstance<BoxTransport, Provider>;
+pub type ZenithInstance = Zenith::ZenithInstance<BoxTransport, Provider, alloy::network::Ethereum>;
 
 impl BuilderConfig {
     /// Load the builder configuration from environment variables.
@@ -247,7 +246,7 @@ fn load_u16(key: &str) -> Result<u16, ConfigError> {
 }
 
 pub fn load_url(key: &str) -> Result<Cow<'static, str>, ConfigError> {
-    load_string(key).map_err(Into::into).map(Into::into)
+    load_string(key).map(Into::into)
 }
 
 pub fn load_address(key: &str) -> Result<Address, ConfigError> {

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -1,8 +1,8 @@
 use alloy::consensus::SignableTransaction;
+use alloy::primitives::{Address, ChainId, B256};
 use alloy::signers::aws::{AwsSigner, AwsSignerError};
 use alloy::signers::local::{LocalSignerError, PrivateKeySigner};
 use alloy::signers::Signature;
-use alloy_primitives::{Address, ChainId, B256};
 use aws_config::BehaviorVersion;
 
 /// Abstraction over local signer or

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -2,12 +2,12 @@ use super::bundler::{Bundle, BundlePoller};
 use super::oauth::Authenticator;
 use super::tx_poller::TxPoller;
 use crate::config::{BuilderConfig, WalletlessProvider};
+use alloy::primitives::{keccak256, Bytes, B256};
 use alloy::providers::Provider;
 use alloy::{
     consensus::{SidecarBuilder, SidecarCoder, TxEnvelope},
     eips::eip2718::Decodable2718,
 };
-use alloy_primitives::{keccak256, Bytes, B256};
 use alloy_rlp::Buf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::OnceLock, time::Duration};
@@ -98,7 +98,7 @@ impl InProgressBlock {
     }
 
     /// Calculate the hash of the in-progress block, finishing the block.
-    pub fn contents_hash(&self) -> alloy_primitives::B256 {
+    pub fn contents_hash(&self) -> B256 {
         self.seal();
         *self.hash.get().unwrap()
     }

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -1,20 +1,19 @@
-//! Bundler service responsible for polling and submitting bundles to the in-progress block.
-use std::time::{Duration, Instant};
+//! Bundler service responsible for managing bundles.
+use super::oauth::Authenticator;
 
 pub use crate::config::BuilderConfig;
-use alloy_primitives::map::HashMap;
-use reqwest::Url;
-use serde::{Deserialize, Serialize};
-use signet_types::SignetEthBundle;
 
 use oauth2::TokenResponse;
-
-use super::oauth::Authenticator;
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use zenith_types::ZenithEthBundle;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Bundle {
     pub id: String,
-    pub bundle: SignetEthBundle,
+    pub bundle: ZenithEthBundle,
 }
 
 /// Response from the tx-pool containing a list of bundles.
@@ -23,6 +22,7 @@ pub struct TxPoolBundleResponse {
     pub bundles: Vec<Bundle>,
 }
 
+/// The BundlePoller polls the tx-pool for bundles and manages the seen bundles.
 pub struct BundlePoller {
     pub config: BuilderConfig,
     pub authenticator: Authenticator,

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -119,7 +119,7 @@ impl Authenticator {
 
 mod tests {
     use crate::config::BuilderConfig;
-    use alloy_primitives::Address;
+    use alloy::primitives::Address;
     use eyre::Result;
 
     #[ignore = "integration test"]

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -6,26 +6,22 @@ use crate::{
 use alloy::{
     consensus::{constants::GWEI_TO_WEI, SimpleCoder},
     eips::BlockNumberOrTag,
-    network::{TransactionBuilder, TransactionBuilder4844},
-    providers::SendableTx,
-    providers::{Provider as _, WalletProvider},
+    network::TransactionBuilder,
+    network::TransactionBuilder4844,
+    primitives::{FixedBytes, U256},
+    providers::{Provider as _, SendableTx, WalletProvider},
     rpc::types::eth::TransactionRequest,
     signers::Signer,
-    sol_types::SolCall,
+    sol_types::{SolCall, SolError},
     transports::TransportError,
 };
-use alloy_primitives::{FixedBytes, U256};
-use alloy_sol_types::SolError;
 use eyre::{bail, eyre};
 use metrics::{counter, histogram};
 use oauth2::TokenResponse;
 use std::time::Instant;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{debug, error, instrument, trace};
-use zenith_types::{
-    SignRequest, SignResponse,
-    Zenith::{self, IncorrectHostBlock},
-};
+use zenith_types::{SignRequest, SignResponse, Zenith, Zenith::IncorrectHostBlock};
 
 macro_rules! spawn_provider_send {
     ($provider:expr, $tx:expr) => {
@@ -138,7 +134,7 @@ impl SubmitTask {
         resp: &SignResponse,
         in_progress: &InProgressBlock,
     ) -> eyre::Result<ControlFlow> {
-        let v: u8 = resp.sig.v().y_parity_byte() + 27;
+        let v = resp.sig.v().into();
         let r: FixedBytes<32> = resp.sig.r().into();
         let s: FixedBytes<32> = resp.sig.s().into();
 

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -1,5 +1,5 @@
 mod tests {
-    use alloy_primitives::Address;
+    use alloy::primitives::Address;
     use builder::{config::BuilderConfig, tasks::oauth::Authenticator};
     use eyre::Result;
 

--- a/tests/tx_poller_test.rs
+++ b/tests/tx_poller_test.rs
@@ -2,8 +2,8 @@ mod tests {
     use std::str::FromStr;
 
     use alloy::consensus::{SignableTransaction, TxEip1559, TxEnvelope};
+    use alloy::primitives::{bytes, Address, TxKind, U256};
     use alloy::signers::{local::PrivateKeySigner, SignerSync};
-    use alloy_primitives::{bytes, Address, TxKind, U256};
     use builder::config::BuilderConfig;
     use builder::tasks::tx_poller;
     use eyre::{Ok, Result};


### PR DESCRIPTION
- bump alloy up
- remove alloy primitives and import primitives from alloy core instead
- fix errors from alloy updates
- remove signet-types and reference zenith-types instead