### PR TITLE
feat: adds bundles to in progress block creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "bin/submit_transaction.rs"
 [dependencies]
 zenith-types = "0.13"
 
-alloy = { version = "0.7.3", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev"] }
+alloy = { version = "0.7.3", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev", "rlp"] }
 alloy-rlp = { version = "0.3.4" }
 
 aws-config = "1.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,6 @@ async-trait = "0.1.80"
 oauth2 = "4.4.2"
 metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.0"
+
+[dev-dependencies]
+httpmock = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,3 @@ async-trait = "0.1.80"
 oauth2 = "4.4.2"
 metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.0"
-
-[dev-dependencies]
-httpmock = "0.7.0"

--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -34,7 +34,7 @@ async fn main() -> eyre::Result<()> {
 
     let submit = SubmitTask {
         authenticator: authenticator.clone(),
-        host_provider,
+        host_provider: host_provider.clone(),
         zenith,
         client: reqwest::Client::new(),
         sequencer_signer,
@@ -44,7 +44,7 @@ async fn main() -> eyre::Result<()> {
 
     let authenticator_jh = authenticator.spawn();
     let (submit_channel, submit_jh) = submit.spawn();
-    let build_jh = builder.spawn(submit_channel);
+    let build_jh = builder.spawn(submit_channel, host_provider.clone());
 
     let port = config.builder_port;
     let server = serve_builder_with_span(([0, 0, 0, 0], port), span);

--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -43,7 +43,7 @@ async fn main() -> eyre::Result<()> {
 
     let authenticator_jh = authenticator.spawn();
     let (submit_channel, submit_jh) = submit.spawn();
-    let build_jh = builder.spawn(submit_channel, ru_provider);
+    let build_jh = builder.spawn(submit_channel);
 
     let port = config.builder_port;
     let server = serve_builder_with_span(([0, 0, 0, 0], port), span);

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ const HOST_RPC_URL: &str = "HOST_RPC_URL";
 const ROLLUP_RPC_URL: &str = "ROLLUP_RPC_URL";
 const TX_BROADCAST_URLS: &str = "TX_BROADCAST_URLS";
 const ZENITH_ADDRESS: &str = "ZENITH_ADDRESS";
+const BUILDER_HELPER_ADDRESS: &str = "BUILDER_HELPER_ADDRESS";
 const QUINCEY_URL: &str = "QUINCEY_URL";
 const BUILDER_PORT: &str = "BUILDER_PORT";
 const SEQUENCER_KEY: &str = "SEQUENCER_KEY"; // empty (to use Quincey) OR AWS key ID (to use AWS signer) OR raw private key (to use local signer)
@@ -33,7 +34,6 @@ const OAUTH_CLIENT_ID: &str = "OAUTH_CLIENT_ID";
 const OAUTH_CLIENT_SECRET: &str = "OAUTH_CLIENT_SECRET";
 const OAUTH_AUTHENTICATE_URL: &str = "OAUTH_AUTHENTICATE_URL";
 const OAUTH_TOKEN_URL: &str = "OAUTH_TOKEN_URL";
-const BUILDER_HELPER_ADDRESS: &str = "BUILDER_HELPER_ADDRESS";
 
 /// Configuration for a builder running a specific rollup on a specific host
 /// chain.

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ const OAUTH_CLIENT_ID: &str = "OAUTH_CLIENT_ID";
 const OAUTH_CLIENT_SECRET: &str = "OAUTH_CLIENT_SECRET";
 const OAUTH_AUTHENTICATE_URL: &str = "OAUTH_AUTHENTICATE_URL";
 const OAUTH_TOKEN_URL: &str = "OAUTH_TOKEN_URL";
+const BUILDER_HELPER_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
 
 /// Configuration for a builder running a specific rollup on a specific host
 /// chain.
@@ -50,6 +51,8 @@ pub struct BuilderConfig {
     pub tx_broadcast_urls: Vec<Cow<'static, str>>,
     /// address of the Zenith contract on Host.
     pub zenith_address: Address,
+    /// address of the Builder Helper contract on Host.
+    pub builder_helper_address: Address,
     /// URL for remote Quincey Sequencer server to sign blocks.
     /// Disregarded if a sequencer_signer is configured.
     pub quincey_url: Cow<'static, str>,
@@ -157,6 +160,7 @@ impl BuilderConfig {
                 .map(Into::into)
                 .collect(),
             zenith_address: load_address(ZENITH_ADDRESS)?,
+            builder_helper_address: load_address(BUILDER_HELPER_ADDRESS)?,
             quincey_url: load_url(QUINCEY_URL)?,
             builder_port: load_u16(BUILDER_PORT)?,
             sequencer_key: load_string_option(SEQUENCER_KEY),

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ const OAUTH_CLIENT_ID: &str = "OAUTH_CLIENT_ID";
 const OAUTH_CLIENT_SECRET: &str = "OAUTH_CLIENT_SECRET";
 const OAUTH_AUTHENTICATE_URL: &str = "OAUTH_AUTHENTICATE_URL";
 const OAUTH_TOKEN_URL: &str = "OAUTH_TOKEN_URL";
-const BUILDER_HELPER_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+const BUILDER_HELPER_ADDRESS: &str = "BUILDER_HELPER_ADDRESS";
 
 /// Configuration for a builder running a specific rollup on a specific host
 /// chain.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,16 @@
 use crate::signer::{LocalOrAws, SignerError};
-use alloy::network::{Ethereum, EthereumWallet};
-use alloy::primitives::Address;
-use alloy::providers::fillers::BlobGasFiller;
-use alloy::providers::{
-    fillers::{ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller},
-    Identity, ProviderBuilder, RootProvider,
+use alloy::{
+    network::{Ethereum, EthereumWallet},
+    primitives::Address,
+    providers::{
+        fillers::{
+            BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
+            WalletFiller,
+        },
+        Identity, ProviderBuilder, RootProvider,
+    },
+    transports::BoxTransport,
 };
-use alloy::transports::BoxTransport;
 use std::{borrow::Cow, env, num, str::FromStr};
 use zenith_types::Zenith;
 

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -12,7 +12,7 @@ use alloy::{
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::OnceLock, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle};
-use tracing::{debug, error, info, trace, Instrument};
+use tracing::{debug, error, info, trace, warn, Instrument};
 use zenith_types::{encode_txns, Alloy2718Coder, ZenithEthBundle};
 
 /// Ethereum's slot time in seconds.
@@ -169,8 +169,10 @@ impl BlockBuilder {
             Ok(bundles) => {
                 for bundle in bundles {
                     let result = self.simulate_bundle(&bundle.bundle, ru_provider).await;
-                    if result.is_ok() {
+                    if let Ok(()) = result {
                         in_progress.ingest_bundle(bundle.clone());
+                    } else {
+                        warn!(id = ?bundle.id, "bundle failed simulation")
                     }
                 }
             }
@@ -187,9 +189,9 @@ impl BlockBuilder {
         bundle: &ZenithEthBundle,
         _ru_provider: &WalletlessProvider,
     ) -> eyre::Result<()> {
-        debug!(hash = ?bundle.bundle.bundle_hash(), block_number = ?bundle.block_number(), "beginning bundle simulation");
         // TODO: Simulate bundles with the Simulation Engine
         // [ENG-672](https://linear.app/initiates/issue/ENG-672/add-support-for-bundles)
+        debug!(hash = ?bundle.bundle.bundle_hash(), block_number = ?bundle.block_number(), "bundle simulations is not implemented yet - skipping simulation");
         Ok(())
     }
 

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -2,6 +2,7 @@ use super::bundler::{Bundle, BundlePoller};
 use super::oauth::Authenticator;
 use super::tx_poller::TxPoller;
 use crate::config::{BuilderConfig, WalletlessProvider};
+use alloy::rpc::types::TransactionRequest;
 use alloy::{
     consensus::{SidecarBuilder, SidecarCoder, TxEnvelope},
     eips::eip2718::Decodable2718,

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -16,7 +16,7 @@ use eyre::{bail, eyre};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::OnceLock, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle};
-use tracing::{debug, error, Instrument};
+use tracing::{error, Instrument};
 use zenith_types::{encode_txns, Alloy2718Coder, ZenithEthBundle};
 
 /// Ethereum's slot time in seconds.
@@ -75,7 +75,7 @@ impl InProgressBlock {
     /// Ingest a bundle into the in-progress block.
     /// Ignores Signed Orders for now.
     pub fn ingest_bundle(&mut self, bundle: Bundle) {
-        debug!(bundle = %bundle.id, "ingesting bundle");
+        tracing::trace!(bundle = %bundle.id, "ingesting bundle");
 
         let txs = bundle
             .bundle

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -87,6 +87,8 @@ impl InProgressBlock {
 
         if let Ok(txs) = txs {
             self.unseal();
+            // extend the transactions with the decoded transactions.
+            // As this builder does not provide bundles landing "top of block", its fine to just extend.
             self.transactions.extend(txs);
         } else {
             error!("failed to decode bundle. dropping");

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -14,7 +14,7 @@ use eyre::{bail, eyre};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::OnceLock, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle};
-use tracing::{error, debug, info, trace, Instrument};
+use tracing::{debug, error, info, trace, Instrument};
 use zenith_types::{encode_txns, Alloy2718Coder, ZenithEthBundle};
 
 /// Ethereum's slot time in seconds.

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -2,15 +2,13 @@ use super::bundler::{Bundle, BundlePoller};
 use super::oauth::Authenticator;
 use super::tx_poller::TxPoller;
 use crate::config::{BuilderConfig, WalletlessProvider};
-use alloy::rpc::types::TransactionRequest;
 use alloy::{
     consensus::{SidecarBuilder, SidecarCoder, TxEnvelope},
     eips::eip2718::Decodable2718,
-    primitives::{keccak256, Bytes, FixedBytes, B256},
+    primitives::{keccak256, Bytes, B256},
     providers::Provider as _,
 };
 use alloy_rlp::Buf;
-use eyre::{bail, eyre};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::OnceLock, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -189,53 +187,15 @@ impl BlockBuilder {
         self.bundle_poller.evict();
     }
 
-    /// Simulates a Flashbots-style `ZenithEthBundle`, simulating each transaction in its bundle
-    /// by calling it against the host provider at the current height against default storage (no state overrides)
-    /// and failing the whole bundle if any transaction not listed in the reverts list fails that call.
+    /// Simulates a Zenith bundle against the rollup state
     async fn simulate_bundle(
         &mut self,
         bundle: &ZenithEthBundle,
-        ru_provider: &WalletlessProvider,
+        _ru_provider: &WalletlessProvider,
     ) -> eyre::Result<()> {
-        // TODO: Simulate bundles with the Simulation Engine
         debug!(hash = ?bundle.bundle.bundle_hash(), block_number = ?bundle.block_number(), "beginning bundle simulation");
-
-        let reverts = &bundle.bundle.reverting_tx_hashes;
-        debug!(reverts = ?reverts, "processing bundle with reverts");
-
-        for tx in &bundle.bundle.txs {
-            let (tx_env, hash) = self.parse_from_bundle(tx)?;
-            debug!(?hash, "tx_envelope parsed from bundle");
-
-            // Simulate and check for reversion allowance
-            match self.simulate_transaction(ru_provider, tx_env).await {
-                Ok(_) => {
-                    // Passed, log trace and continue
-                    debug!(tx = %hash, "tx passed simulation");
-                    continue;
-                }
-                Err(sim_err) => {
-                    // Failed, only continfue if tx is marked in revert list
-                    if reverts.contains(&hash) {
-                        debug!(?sim_err, "tx failed simulation but is in revert list; skipping.");
-                        continue;
-                    } else {
-                        bail!("tx {hash} failed simulation but was not marked as allowed to revert")
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Simulates a rollup transaction by calling it on the ru provider at the current height with the current state.
-    async fn simulate_transaction(
-        &self,
-        ru_provider: &WalletlessProvider,
-        tx_env: TxEnvelope,
-    ) -> eyre::Result<()> {
-        let tx = TransactionRequest::from_transaction(tx_env);
-        ru_provider.call(&tx).await?;
+        // TODO: Simulate bundles with the Simulation Engine
+        // [ENG-672](https://linear.app/initiates/issue/ENG-672/add-support-for-bundles)
         Ok(())
     }
 
@@ -270,18 +230,6 @@ impl BlockBuilder {
     // add a buffer to the beginning of the block slot.
     fn secs_to_next_target(&self) -> u64 {
         self.secs_to_next_slot() + self.config.target_slot_time
-    }
-
-    /// Parses bytes into a transaction envelope that is compatible with Flashbots-style bundles
-    fn parse_from_bundle(&self, tx: &Bytes) -> Result<(TxEnvelope, FixedBytes<32>), eyre::Error> {
-        let tx_env = TxEnvelope::decode_2718(&mut tx.chunk())?;
-        let hash = tx_env.tx_hash().to_owned();
-        debug!(hash = %hash, "decoded bundle tx");
-        if tx_env.is_eip4844() {
-            error!("eip-4844 disallowed");
-            return Err(eyre!("EIP-4844 transactions are not allowed in bundles"));
-        }
-        Ok((tx_env, hash))
     }
 
     /// Spawn the block builder task, returning the inbound channel to it, and

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -7,8 +7,8 @@ use alloy::{
     eips::eip2718::Decodable2718,
     primitives::{keccak256, Bytes, B256},
     providers::Provider as _,
+    rlp::Buf,
 };
-use alloy_rlp::Buf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::OnceLock, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle};

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -230,11 +230,11 @@ impl BlockBuilder {
     /// Simulates a rollup transaction by calling it on the ru provider at the current height with the current state.
     async fn simulate_transaction(
         &self,
-        _ru_provider: &WalletlessProvider,
-        _tx_env: TxEnvelope,
+        ru_provider: &WalletlessProvider,
+        tx_env: TxEnvelope,
     ) -> eyre::Result<()> {
-        // let tx = TransactionRequest::from_transaction(tx_env);
-        // ru_provider.call(&tx).await?;
+        let tx = TransactionRequest::from_transaction(tx_env);
+        ru_provider.call(&tx).await?;
         Ok(())
     }
 

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -162,12 +162,6 @@ impl BlockBuilder {
         ru_provider: &WalletlessProvider,
         in_progress: &mut InProgressBlock,
     ) {
-        // Authenticate before fetching to ensure access to a valid token
-        if let Err(err) = self.bundle_poller.authenticator.authenticate().await {
-            error!(err = %err, "bundle fetcher failed to authenticate");
-            return;
-        }
-
         trace!("query bundles from cache");
         let bundles = self.bundle_poller.check_bundle_cache().await;
         // TODO: Sort bundles received from cache

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -164,6 +164,7 @@ mod tests {
             oauth_token_url: "http://localhost:9000".into(),
             tx_broadcast_urls: vec!["http://localhost:9000".into()],
             oauth_token_refresh_interval: 300, // 5 minutes
+            builder_helper_address: Address::default(),
         };
         Ok(config)
     }

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -157,7 +157,7 @@ impl SubmitTask {
         let tx = self
             .build_blob_tx(fills, header, v, r, s, in_progress)?
             .with_from(self.host_provider.default_signer_address())
-            .with_to(self.config.zenith_address)
+            .with_to(self.config.builder_helper_address)
             .with_gas_limit(1_000_000);
 
         if let Err(TransportError::ErrorResp(e)) =

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -41,6 +41,7 @@ mod tests {
             oauth_token_url: "http://localhost:8080".into(),
             tx_broadcast_urls: vec!["http://localhost:9000".into()],
             oauth_token_refresh_interval: 300, // 5 minutes
+            builder_helper_address: Address::default(),
         };
         Ok(config)
     }

--- a/tests/tx_poller_test.rs
+++ b/tests/tx_poller_test.rs
@@ -87,6 +87,7 @@ mod tests {
             oauth_authenticate_url: "http://localhost:8080".into(),
             oauth_token_url: "http://localhost:8080".into(),
             oauth_token_refresh_interval: 300, // 5 minutes
+            builder_helper_address: Address::default(),
         };
         Ok(config)
     }


### PR DESCRIPTION
# tl;dr 

This PR adds bundle ingestion from the tx-pool to the Signet Builder.

## Changes 

- `InProgressBlock` building process now checks the cache for bundles
- Ingests any new bundles that it finds into the in progress block
- Changes the block submission call to use the BuilderHelper contract
- Stubs out bundle simulation (see [ENG-640](https://linear.app/initiates/issue/ENG-640/add-simulation-engine-to-the-example-builder))

## Configuration updates

This PR requires an environment variable (the builder helper contract address) be added to the configuration, and thus must go in after the config is added to the environment in [the-infra PR #308](https://github.com/init4tech/the-infra/pull/308)

Closes [ENG-549](https://linear.app/initiates/issue/ENG-629/add-bundle-with-signed-orders-support-by-using-the-helper-contract-to)
Supersedes builder [PR #34](https://github.com/init4tech/builder/pull/34)
