### PR TITLE
adds checks before attempting to connect broadcast providers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -221,13 +221,17 @@ impl BuilderConfig {
     pub async fn connect_additional_broadcast(
         &self,
     ) -> Result<Vec<RootProvider<BoxTransport>>, ConfigError> {
-        let mut providers = Vec::with_capacity(self.tx_broadcast_urls.len());
-        for url in self.tx_broadcast_urls.iter() {
-            let provider =
-                ProviderBuilder::new().on_builtin(url).await.map_err(Into::<ConfigError>::into)?;
-            providers.push(provider);
+        if self.tx_broadcast_urls.len() > 0 && self.tx_broadcast_urls[0] != "" {
+            let mut providers = Vec::with_capacity(self.tx_broadcast_urls.len());
+            for url in self.tx_broadcast_urls.iter() {
+                let provider =
+                    ProviderBuilder::new().on_builtin(url).await.map_err(Into::<ConfigError>::into)?;
+                providers.push(provider);
+            }
+            Ok(providers)
+        } else {
+            Ok(vec![])
         }
-        Ok(providers)
     }
 
     pub fn connect_zenith(&self, provider: Provider) -> ZenithInstance {

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,8 +224,10 @@ impl BuilderConfig {
         if self.tx_broadcast_urls.len() > 0 && self.tx_broadcast_urls[0] != "" {
             let mut providers = Vec::with_capacity(self.tx_broadcast_urls.len());
             for url in self.tx_broadcast_urls.iter() {
-                let provider =
-                    ProviderBuilder::new().on_builtin(url).await.map_err(Into::<ConfigError>::into)?;
+                let provider = ProviderBuilder::new()
+                    .on_builtin(url)
+                    .await
+                    .map_err(Into::<ConfigError>::into)?;
                 providers.push(provider);
             }
             Ok(providers)

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,7 +221,7 @@ impl BuilderConfig {
     pub async fn connect_additional_broadcast(
         &self,
     ) -> Result<Vec<RootProvider<BoxTransport>>, ConfigError> {
-        if self.tx_broadcast_urls.len() > 0 && self.tx_broadcast_urls[0] != "" {
+        if !self.tx_broadcast_urls.is_empty() && self.tx_broadcast_urls[0] != "" {
             let mut providers = Vec::with_capacity(self.tx_broadcast_urls.len());
             for url in self.tx_broadcast_urls.iter() {
                 let provider = ProviderBuilder::new()


### PR DESCRIPTION
# tl;dr 
checks for empty string before attempting to create providers from the builder's tx_broadcast_urls configuration field. 