### PR TITLE
feat: otlp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ hex = { package = "const-hex", version = "1", default-features = false, features
 ] }
 
 serde = { version = "1.0.197", features = ["derive"] }
-tracing = "0.1.40"
 
 axum = "0.7.5"
 eyre = "0.6.12"
@@ -45,9 +44,20 @@ ruint = "1.12.1"
 serde_json = "1.0"
 thiserror = "1.0.68"
 tokio = { version = "1.36.0", features = ["full", "macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.18"
 
 async-trait = "0.1.80"
 oauth2 = "4.4.2"
+
 metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.0"
+
+# Tracing
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["registry"] }
+
+# OTLP
+tracing-opentelemetry = "0.29.0"
+opentelemetry_sdk = "0.28.0"
+opentelemetry = "0.28.0"
+opentelemetry-otlp = "0.28.0"
+opentelemetry-semantic-conventions = { version = "0.28.0", features = ["semconv_experimental"] }

--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -64,21 +64,23 @@ async fn main() -> eyre::Result<()> {
     let port = config.builder_port;
     let server = serve_builder_with_span(([0, 0, 0, 0], port), span);
 
+    let slang_definition = r#"in this context, "cooked" means that it finished running"#;
+
     select! {
         _ = submit_jh => {
-            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "submit is cooked");
+            tracing::info!(slang_definition, "submit is cooked");
         },
         _ = metrics_jh => {
-            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "metrics is cooked");
+            tracing::info!(slang_definition, "metrics is cooked");
         },
         _ = build_jh => {
-            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "build is cooked");
+            tracing::info!(slang_definition, "build is cooked");
         }
         _ = server => {
-            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "server is cooked");
+            tracing::info!(slang_definition, "server is cooked");
         }
         _ = authenticator_jh => {
-            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "authenticator is cooked");
+            tracing::info!(slang_definition, "authenticator is cooked");
         }
     }
 

--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -66,19 +66,19 @@ async fn main() -> eyre::Result<()> {
 
     select! {
         _ = submit_jh => {
-            tracing::info!("submit is cooked");
+            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "submit is cooked");
         },
         _ = metrics_jh => {
-            tracing::info!("metrics is cooked");
+            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "metrics is cooked");
         },
         _ = build_jh => {
-            tracing::info!("build is cooked");
+            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "build is cooked");
         }
         _ = server => {
-            tracing::info!("server is cooked");
+            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "server is cooked");
         }
         _ = authenticator_jh => {
-            tracing::info!("authenticator is cooked");
+            tracing::info!(slang_definition = r#"in this context, "cooked" means that it finished running"#, "authenticator is cooked");
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod otlp;
 pub mod service;
 pub mod signer;
 pub mod tasks;

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -1,0 +1,149 @@
+use std::time::Duration;
+
+use opentelemetry::{trace::TracerProvider, KeyValue};
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::Resource;
+use opentelemetry_semantic_conventions::{
+    attribute::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_NAME, SERVICE_VERSION},
+    SCHEMA_URL,
+};
+use reqwest::Url;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::Layer;
+
+const OTEL_ENDPOINT: &str = "OTEL_ENDPOINT";
+const OTEL_PROTOCOL: &str = "OTEL_PROTOCOL";
+const OTEL_LEVEL: &str = "OTEL_LEVEL";
+const OTEL_TIMEOUT: &str = "OTEL_TIMEOUT";
+const OTEL_ENVIRONMENT: &str = "OTEL_ENVIRONMENT_NAME";
+
+pub struct OtelGuard(SdkTracerProvider, tracing::Level);
+
+impl OtelGuard {
+    /// Get a tracer from the provider.
+    fn tracer(&self, s: &'static str) -> opentelemetry_sdk::trace::Tracer {
+        self.0.tracer(s)
+    }
+
+    /// Create a filtered tracing layer.
+    pub fn layer<S>(&self) -> impl Layer<S>
+    where
+        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    {
+        let tracer = self.tracer("tracing-otel-subscriber");
+        tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(LevelFilter::from_level(self.1))
+    }
+}
+
+impl Drop for OtelGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.0.shutdown() {
+            eprintln!("{err:?}");
+        }
+    }
+}
+
+/// OTLP protocol options.
+#[derive(Debug, Clone, Copy)]
+pub enum OtlpProtocols {
+    /// GRPC.
+    Grpc,
+    /// Binary.
+    Binary,
+    /// JSON.
+    Json,
+}
+
+impl std::str::FromStr for OtlpProtocols {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            s if s.eq_ignore_ascii_case("grpc") => Ok(Self::Grpc),
+            s if s.eq_ignore_ascii_case("binary") => Ok(Self::Binary),
+            s if s.eq_ignore_ascii_case("json") => Ok(Self::Json),
+            _ => Err(format!("Invalid protocol: {}", s)),
+        }
+    }
+}
+
+impl From<OtlpProtocols> for opentelemetry_otlp::Protocol {
+    fn from(protocol: OtlpProtocols) -> Self {
+        match protocol {
+            OtlpProtocols::Grpc => Self::Grpc,
+            OtlpProtocols::Binary => Self::HttpBinary,
+            OtlpProtocols::Json => Self::HttpJson,
+        }
+    }
+}
+
+/// Otel configuration
+#[derive(Debug, Clone)]
+pub struct OtelConfig {
+    /// The endpoint to send traces to, should be some valid HTTP endpoint for
+    /// OTLP.
+    pub endpoint: Url,
+    /// Defaults to JSON.
+    pub protocol: OtlpProtocols,
+    /// Defaults to DEBUG.
+    pub level: tracing::Level,
+    /// Defaults to 1 second. Specified in Milliseconds.
+    pub timeout: Duration,
+
+    /// OTEL convenition `deployment.environment.name`
+    pub environment: String,
+}
+
+impl OtelConfig {
+    /// Load from env vars.
+    pub fn load() -> Option<Self> {
+        let endpoint = std::env::var(OTEL_ENDPOINT).ok()?.parse().ok()?;
+
+        let protocol = std::env::var(OTEL_PROTOCOL)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(OtlpProtocols::Json);
+
+        let level = std::env::var(OTEL_LEVEL)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(tracing::Level::DEBUG);
+
+        let timeout = Duration::from_millis(
+            std::env::var(OTEL_TIMEOUT).ok().and_then(|v| v.parse().ok()).unwrap_or(1000),
+        );
+
+        let environment =
+            std::env::var(OTEL_ENVIRONMENT).ok().unwrap_or_else(|| "unknown".to_owned());
+
+        Some(Self { endpoint, protocol, level, timeout, environment })
+    }
+
+    fn resource(&self) -> Resource {
+        Resource::builder()
+            .with_schema_url(
+                [
+                    KeyValue::new(SERVICE_NAME, env!("CARGO_PKG_NAME")),
+                    KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+                    KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, self.environment.clone()),
+                ],
+                SCHEMA_URL,
+            )
+            .build()
+    }
+
+    pub fn provider(&self) -> OtelGuard {
+        let exporter = opentelemetry_otlp::SpanExporter::builder().with_http().build().unwrap();
+
+        let provider = SdkTracerProvider::builder()
+            // Customize sampling strategy
+            // If export trace to AWS X-Ray, you can use XrayIdGenerator
+            .with_resource(self.resource())
+            .with_batch_exporter(exporter)
+            .build();
+
+        OtelGuard(provider, self.level)
+    }
+}

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -17,6 +17,21 @@ const OTEL_LEVEL: &str = "OTEL_LEVEL";
 const OTEL_TIMEOUT: &str = "OTEL_TIMEOUT";
 const OTEL_ENVIRONMENT: &str = "OTEL_ENVIRONMENT_NAME";
 
+/// Drop guard for the Otel provider. This will shutdown the provider when
+/// dropped, and generally should be held for the lifetime of the `main`
+/// function.
+///
+/// ```
+/// # use builder::otlp::{OtelConfig, OtelGuard};
+/// # fn test() {
+/// fn main() {
+///     let cfg = OtelConfig::load().unwrap();
+///     let guard = cfg.provider();
+///     // do stuff
+///     // drop the guard when the program is done
+/// }
+/// # }
+/// ```
 pub struct OtelGuard(SdkTracerProvider, tracing::Level);
 
 impl OtelGuard {

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -60,7 +60,7 @@ impl Drop for OtelGuard {
     }
 }
 
-/// OTLP protocol options.
+/// OTLP protocol choices
 #[derive(Debug, Clone, Copy, Default)]
 pub enum OtlpProtocols {
     /// GRPC.
@@ -95,7 +95,20 @@ impl From<OtlpProtocols> for opentelemetry_otlp::Protocol {
     }
 }
 
-/// Otel configuration
+/// Otel configuration. This struct is intended to be loaded from the env vars
+///
+/// The env vars it checks are:
+/// - OTEL_ENDPOINT - optional. The endpoint to send traces to, should be some
+///   valid URL. If not specified, then [`OtelConfig::load`] will return
+///   [`None`].
+/// - OTEL_PROTOCOL - optional. Specifies the OTLP protocol to use, should be
+///   one of "grpc", "binary" or "json". Defaults to json.
+/// - OTEL_LEVEL - optional. Specifies the minimum [`tracing::Level`] to
+///   export. Defaults to [`tracing::Level::DEBUG`].
+/// - OTEL_TIMEOUT - optional. Specifies the timeout for the exporter in
+///   **milliseconds**. Defaults to 1000ms, which is equivalent to 1 second.
+/// - OTEL_ENVIRONMENT_NAME - optional. Value for the `deployment.environment.
+///   name` resource key according to the OTEL conventions.
 #[derive(Debug, Clone)]
 pub struct OtelConfig {
     /// The endpoint to send traces to, should be some valid HTTP endpoint for
@@ -114,6 +127,20 @@ pub struct OtelConfig {
 
 impl OtelConfig {
     /// Load from env vars.
+    ///
+    /// The env vars it checks are:
+    /// - OTEL_ENDPOINT - optional. The endpoint to send traces to, should be
+    ///   some  valid URL. If not specified, then [`OtelConfig::load`] will
+    ///   return [`None`].
+    /// - OTEL_PROTOCOL - optional. Specifies the OTLP protocol to use, should
+    ///   be one of "grpc", "binary" or "json". Defaults to json.
+    /// - OTEL_LEVEL - optional. Specifies the minimum [`tracing::Level`] to
+    ///   export. Defaults to [`tracing::Level::DEBUG`].
+    /// - OTEL_TIMEOUT - optional. Specifies the timeout for the exporter in
+    ///   **milliseconds**. Defaults to 1000ms, which is equivalent to 1 second.
+    /// - OTEL_ENVIRONMENT_NAME - optional. Value for the
+    ///   `deployment.environment.name` resource key according to the OTEL
+    ///   conventions.
     pub fn load() -> Option<Self> {
         // load endpoint from env. ignore empty values (shortcut return None), parse, and print the error if any using inspect_err
         let endpoint =

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -46,13 +46,14 @@ impl Drop for OtelGuard {
 }
 
 /// OTLP protocol options.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum OtlpProtocols {
     /// GRPC.
     Grpc,
     /// Binary.
     Binary,
     /// JSON.
+    #[default]
     Json,
 }
 
@@ -101,10 +102,8 @@ impl OtelConfig {
     pub fn load() -> Option<Self> {
         let endpoint = std::env::var(OTEL_ENDPOINT).ok()?.parse().ok()?;
 
-        let protocol = std::env::var(OTEL_PROTOCOL)
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(OtlpProtocols::Json);
+        let protocol =
+            std::env::var(OTEL_PROTOCOL).ok().and_then(|v| v.parse().ok()).unwrap_or_default();
 
         let level = std::env::var(OTEL_LEVEL)
             .ok()

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -100,7 +100,11 @@ pub struct OtelConfig {
 impl OtelConfig {
     /// Load from env vars.
     pub fn load() -> Option<Self> {
-        let endpoint = std::env::var(OTEL_ENDPOINT).ok()?.parse().ok()?;
+        // load endpoint from env. ignore empty values (shortcut return None), parse, and print the error if any using inspect_err
+        let endpoint =
+            std::env::var(OTEL_ENDPOINT).inspect_err(|e| println!("{e}")).ok().and_then(|v| {
+                v.parse().inspect_err(|e| println!("Error parsing url: {e}. Input was {v}")).ok()
+            })?;
 
         let protocol =
             std::env::var(OTEL_PROTOCOL).ok().and_then(|v| v.parse().ok()).unwrap_or_default();


### PR DESCRIPTION
cc @rswanson adds the following: 
env configuration

```
const OTEL_ENDPOINT: &str = "OTEL_ENDPOINT";
const OTEL_PROTOCOL: &str = "OTEL_PROTOCOL";
const OTEL_LEVEL: &str = "OTEL_LEVEL";
const OTEL_TIMEOUT: &str = "OTEL_TIMEOUT";
const OTEL_ENVIRONMENT: &str = "OTEL_ENVIRONMENT_NAME";
```

`endpoint`: a URL. if configured, starts the exporter. omit for off.
`protocol`: legal values are grpc, json, binary. defaults to json
`level`: legal values are off, error, warn, info, debug, trace. defaults to trace
`timeout`: milliseconds as u64. defaults to 1000
`environment`: a string. optional. any value. name like "prod" or "dev" recommended. defaults to "unknown"


appears from [groundcover docs](https://docs.groundcover.com/architecture/incloud-managed/ingestion-endpoints#opentelemetry) that the following should be used

`endpoint` = `{inCloud_Site}`
`protocol` = `grpc`
