### PR TITLE
chore: use bin base

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ name = "transaction-submitter"
 path = "bin/submit_transaction.rs"
 
 [dependencies]
+init4-bin-base = "0.1.0"
+
 zenith-types = "0.13"
 
 alloy = { version = "0.7.3", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev", "rlp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ init4-bin-base = "0.1.0"
 zenith-types = "0.13"
 
 alloy = { version = "0.7.3", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev", "rlp"] }
-alloy-rlp = { version = "0.3.4" }
 
 aws-config = "1.1.7"
 aws-sdk-kms = "1.15.0"
@@ -43,13 +42,9 @@ axum = "0.7.5"
 eyre = "0.6.12"
 openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.11.24", features = ["blocking", "json"] }
-ruint = "1.12.1"
 serde_json = "1.0"
 thiserror = "1.0.68"
 tokio = { version = "1.36.0", features = ["full", "macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.18"
 
 async-trait = "0.1.80"
 oauth2 = "4.4.2"
-metrics = "0.24.1"
-metrics-exporter-prometheus = "0.16.0"

--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -6,21 +6,19 @@ use builder::tasks::block::BlockBuilder;
 use builder::tasks::metrics::MetricsTask;
 use builder::tasks::oauth::Authenticator;
 use builder::tasks::submit::SubmitTask;
-use metrics_exporter_prometheus::PrometheusBuilder;
 
 use tokio::select;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    tracing_subscriber::fmt::try_init().unwrap();
+    let _guard = init4_bin_base::init4();
+
     let span = tracing::info_span!("zenith-builder");
 
     let config = BuilderConfig::load_from_env()?.clone();
     let host_provider = config.connect_host_provider().await?;
     let ru_provider = config.connect_ru_provider().await?;
     let authenticator = Authenticator::new(&config);
-
-    PrometheusBuilder::new().install().expect("failed to install prometheus exporter");
 
     tracing::debug!(rpc_url = config.host_rpc_url.as_ref(), "instantiated provider");
 

--- a/bin/submit_transaction.rs
+++ b/bin/submit_transaction.rs
@@ -7,18 +7,16 @@ use alloy::{
 };
 use aws_config::BehaviorVersion;
 use builder::config::{load_address, load_string, load_u64, load_url, Provider};
-use metrics::counter;
-use metrics::histogram;
-use metrics_exporter_prometheus::PrometheusBuilder;
+use init4_bin_base::{
+    deps::metrics::{counter, histogram},
+    init4,
+};
 use std::time::{Duration, Instant};
 use tokio::time::timeout;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::try_init().unwrap();
-
-    tracing::trace!("installing metrics collector");
-    PrometheusBuilder::new().install().expect("failed to install prometheus exporter");
+    init4();
 
     tracing::trace!("connecting to provider");
     let (provider, recipient_address, sleep_time) = connect_from_config().await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,7 +242,7 @@ impl BuilderConfig {
     }
 
     /// Connect to the Zenith instance, using the specified provider.
-    pub fn connect_zenith(&self, provider: Provider) -> ZenithInstance {
+    pub const fn connect_zenith(&self, provider: Provider) -> ZenithInstance {
         Zenith::new(self.zenith_address, provider)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,7 @@ pub struct BuilderConfig {
     pub oauth_token_refresh_interval: u64,
 }
 
+/// Error loading the configuration.
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     /// Error loading from environment variable
@@ -148,7 +149,11 @@ pub type WalletlessProvider = FillProvider<
     BoxTransport,
     Ethereum,
 >;
-pub type ZenithInstance = Zenith::ZenithInstance<BoxTransport, Provider, alloy::network::Ethereum>;
+
+/// A Zenith contract instance, using some provider `P` (defaults to
+/// [`Provider`]).
+pub type ZenithInstance<P = Provider> =
+    Zenith::ZenithInstance<BoxTransport, P, alloy::network::Ethereum>;
 
 impl BuilderConfig {
     /// Load the builder configuration from environment variables.
@@ -187,10 +192,12 @@ impl BuilderConfig {
         })
     }
 
+    /// Connect to the Builder signer.
     pub async fn connect_builder_signer(&self) -> Result<LocalOrAws, ConfigError> {
         LocalOrAws::load(&self.builder_key, Some(self.host_chain_id)).await.map_err(Into::into)
     }
 
+    /// Connect to the Sequencer signer.
     pub async fn connect_sequencer_signer(&self) -> Result<Option<LocalOrAws>, ConfigError> {
         match &self.sequencer_key {
             Some(sequencer_key) => LocalOrAws::load(sequencer_key, Some(self.host_chain_id))
@@ -221,6 +228,7 @@ impl BuilderConfig {
             .map_err(Into::into)
     }
 
+    /// Connect additional broadcast providers.
     pub async fn connect_additional_broadcast(
         &self,
     ) -> Result<Vec<RootProvider<BoxTransport>>, ConfigError> {
@@ -233,33 +241,41 @@ impl BuilderConfig {
         Ok(providers)
     }
 
+    /// Connect to the Zenith instance, using the specified provider.
     pub fn connect_zenith(&self, provider: Provider) -> ZenithInstance {
         Zenith::new(self.zenith_address, provider)
     }
 }
 
+/// Load a string from an environment variable.
 pub fn load_string(key: &str) -> Result<String, ConfigError> {
     env::var(key).map_err(|_| ConfigError::missing(key))
 }
 
+/// Load a string from an environment variable, returning None if the variable
+/// is not set.
 fn load_string_option(key: &str) -> Option<String> {
     load_string(key).ok()
 }
 
+/// Load a boolean from an environment variable.
 pub fn load_u64(key: &str) -> Result<u64, ConfigError> {
     let val = load_string(key)?;
     val.parse::<u64>().map_err(Into::into)
 }
 
+/// Load a u16 from an environment variable.
 fn load_u16(key: &str) -> Result<u16, ConfigError> {
     let val = load_string(key)?;
     val.parse::<u16>().map_err(Into::into)
 }
 
+/// Load a URL from an environment variable.
 pub fn load_url(key: &str) -> Result<Cow<'static, str>, ConfigError> {
     load_string(key).map(Into::into)
 }
 
+/// Load an address from an environment variable.
 pub fn load_address(key: &str) -> Result<Address, ConfigError> {
     let address = load_string(key)?;
     Address::from_str(&address).map_err(Into::into)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,30 @@
+//! Builder binary components.
+
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    unreachable_pub,
+    clippy::missing_const_for_fn,
+    rustdoc::all
+)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+/// Configuration for the Builder binary.
 pub mod config;
+
+/// Implements the `/healthcheck` endpoint.
 pub mod service;
+
+/// Builder transaction signer.
 pub mod signer;
+
+/// Actor-based tasks used to construct a builder.
 pub mod tasks;
+
+/// Utilities.
 pub mod utils;
 
 use openssl as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 pub mod config;
 pub mod service;
 pub mod signer;
 pub mod tasks;
 pub mod utils;
+
+use openssl as _;

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -8,10 +8,13 @@ use aws_config::BehaviorVersion;
 /// Abstraction over local signer or
 #[derive(Debug, Clone)]
 pub enum LocalOrAws {
+    /// Local signer
     Local(PrivateKeySigner),
+    /// AWS signer
     Aws(AwsSigner),
 }
 
+/// Error during signing
 #[derive(Debug, thiserror::Error)]
 pub enum SignerError {
     /// Error during [`AwsSigner`] instantiation

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -116,16 +116,22 @@ impl InProgressBlock {
     }
 }
 
-/// BlockBuilder is a task that periodically builds a block then sends it for signing and submission.
+/// BlockBuilder is a task that periodically builds a block then sends it for
+/// signing and submission.
+#[derive(Debug)]
 pub struct BlockBuilder {
+    /// Configuration.
     pub config: BuilderConfig,
+    /// A provider that cannot sign transactions.
     pub ru_provider: WalletlessProvider,
+    /// A poller for fetching transactions.
     pub tx_poller: TxPoller,
+    /// A poller for fetching bundles.
     pub bundle_poller: BundlePoller,
 }
 
 impl BlockBuilder {
-    // create a new block builder with the given config.
+    /// Create a new block builder with the given config.
     pub fn new(
         config: &BuilderConfig,
         authenticator: Authenticator,
@@ -139,7 +145,8 @@ impl BlockBuilder {
         }
     }
 
-    /// Fetches transactions from the cache and ingests them into the in progress block
+    /// Fetches transactions from the cache and ingests them into the in
+    /// progress block
     async fn get_transactions(&mut self, in_progress: &mut InProgressBlock) {
         trace!("query transactions from cache");
         let txns = self.tx_poller.check_tx_cache().await;

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -28,7 +28,7 @@ pub struct InProgressBlock {
 
 impl InProgressBlock {
     /// Create a new `InProgressBlock`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { transactions: Vec::new(), raw_encoding: OnceLock::new(), hash: OnceLock::new() }
     }
 

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -10,22 +10,31 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use zenith_types::ZenithEthBundle;
 
+/// A bundle response from the tx-pool endpoint, containing a UUID and a
+/// [`ZenithEthBundle`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Bundle {
+    /// The bundle id (a UUID)
     pub id: String,
+    /// The bundle itself
     pub bundle: ZenithEthBundle,
 }
 
 /// Response from the tx-pool containing a list of bundles.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TxPoolBundleResponse {
+    /// the list of bundles
     pub bundles: Vec<Bundle>,
 }
 
 /// The BundlePoller polls the tx-pool for bundles and manages the seen bundles.
+#[derive(Debug)]
 pub struct BundlePoller {
+    /// Configuration
     pub config: BuilderConfig,
+    /// [`Authenticator`] for fetching OAuth tokens
     pub authenticator: Authenticator,
+    /// Already seen bundle UUIDs
     pub seen_uuids: HashMap<String, Instant>,
 }
 

--- a/src/tasks/metrics.rs
+++ b/src/tasks/metrics.rs
@@ -1,6 +1,6 @@
 use crate::config::Provider;
 use alloy::{primitives::TxHash, providers::Provider as _};
-use metrics::{counter, histogram};
+use init4_bin_base::deps::metrics::{counter, histogram};
 use std::time::Instant;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{debug, error};

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,6 +1,17 @@
+/// Block creation task
 pub mod block;
+
+/// Bundle poller task
 pub mod bundler;
+
+/// Tx submission metric task
 pub mod metrics;
+
+/// OAuth token refresh task
 pub mod oauth;
+
+/// Tx submission task
 pub mod submit;
+
+/// Tx polling task
 pub mod tx_poller;

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -18,6 +18,7 @@ type Token = StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>;
 /// Readers are guaranteed to not read stale tokens as the [RwLock] guarantees that write tasks (refreshing the token) will claim priority over read access.
 #[derive(Debug, Clone)]
 pub struct Authenticator {
+    /// Configuration
     pub config: BuilderConfig,
     inner: Arc<RwLock<AuthenticatorInner>>,
 }
@@ -26,6 +27,7 @@ pub struct Authenticator {
 /// Contains the token that is being used for authentication.
 #[derive(Debug)]
 pub struct AuthenticatorInner {
+    /// The token
     pub token: Option<Token>,
 }
 
@@ -36,6 +38,7 @@ impl Default for AuthenticatorInner {
 }
 
 impl AuthenticatorInner {
+    /// Creates a new AuthenticatorInner with no token set.
     pub fn new() -> Self {
         Self { token: None }
     }
@@ -140,7 +143,7 @@ mod tests {
     }
 
     #[allow(dead_code)]
-    pub fn setup_test_config() -> Result<BuilderConfig> {
+    fn setup_test_config() -> Result<BuilderConfig> {
         let config = BuilderConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,

--- a/src/tasks/oauth.rs
+++ b/src/tasks/oauth.rs
@@ -39,7 +39,7 @@ impl Default for AuthenticatorInner {
 
 impl AuthenticatorInner {
     /// Creates a new AuthenticatorInner with no token set.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { token: None }
     }
 }

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -16,7 +16,7 @@ use alloy::{
     transports::TransportError,
 };
 use eyre::{bail, eyre};
-use metrics::{counter, histogram};
+use init4_bin_base::deps::metrics::{counter, histogram};
 use oauth2::TokenResponse;
 use std::time::Instant;
 use tokio::{sync::mpsc, task::JoinHandle};

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -43,13 +43,19 @@ macro_rules! spawn_provider_send {
 
 use super::oauth::Authenticator;
 
+/// Control flow for transaction submission.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ControlFlow {
+    /// Retry
     Retry,
+    /// Skip
     Skip,
+    /// Succesfully submitted
     Done,
 }
 
 /// Submits sidecars in ethereum txns to mainnet ethereum
+#[derive(Debug, Clone)]
 pub struct SubmitTask {
     /// Ethereum Provider
     pub host_provider: Provider,
@@ -63,7 +69,7 @@ pub struct SubmitTask {
     pub config: crate::config::BuilderConfig,
     /// Authenticator
     pub authenticator: Authenticator,
-    // Channel over which to send pending transactions
+    /// Channel over which to send pending transactions
     pub outbound_tx_channel: mpsc::UnboundedSender<TxHash>,
 }
 

--- a/src/tasks/tx_poller.rs
+++ b/src/tasks/tx_poller.rs
@@ -6,16 +6,18 @@ use serde_json::from_slice;
 
 pub use crate::config::BuilderConfig;
 
+/// Response from the tx-pool endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TxPoolResponse {
     transactions: Vec<TxEnvelope>,
 }
 
 /// Implements a poller for the block builder to pull transactions from the transaction pool.
+#[derive(Debug)]
 pub struct TxPoller {
-    // config for the builder
+    /// config for the builder
     pub config: BuilderConfig,
-    // Reqwest client for fetching transactions from the tx-pool
+    /// Reqwest client for fetching transactions from the tx-pool
     pub client: Client,
 }
 


### PR DESCRIPTION
use `init4()` to set up metrics and tracing
bring crate in line with clippy and code standards policies in other repos