### PR TITLE
updates bundler to streaming actor pattern

### DIFF
--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -180,7 +180,6 @@ impl BlockBuilder {
                 error!(error = %e, "error polling bundles");
             }
         }
-        self.bundle_poller.evict();
     }
 
     /// Simulates a Zenith bundle against the rollup state

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -43,7 +43,11 @@ impl BundlePoller {
     }
 
     /// Creates a new BundlePoller from the provided builder config and with the specified poll interval in ms.
-    pub fn new_with_poll_interval_ms(config: &BuilderConfig, authenticator: Authenticator, poll_interval_ms: u64) -> Self {
+    pub fn new_with_poll_interval_ms(
+        config: &BuilderConfig,
+        authenticator: Authenticator,
+        poll_interval_ms: u64,
+    ) -> Self {
         Self { config: config.clone(), authenticator, poll_interval_ms }
     }
 

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -89,11 +89,3 @@ impl BundlePoller {
         (inbound, jh)
     }
 }
-
-impl PartialEq for Bundle {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl Eq for Bundle {}


### PR DESCRIPTION
# Updates builder to streaming actor pattern

The block builder was previously just calling the fetch function from the bundle service. Instead, this PR makes it so that bundles are streamed out from the cache to a simulator task that processes and builds them into a valid block. 

Closes ENG-791