### PR TITLE
chore: updates builder to use signet-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,3 @@ tokio = { version = "1.36.0", features = ["full", "macros", "rt-multi-thread"] }
 
 async-trait = "0.1.80"
 oauth2 = "4.4.2"
-metrics = "0.24.1"
-metrics-exporter-prometheus = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ name = "transaction-submitter"
 path = "bin/submit_transaction.rs"
 
 [dependencies]
-init4-bin-base = { path = "../bin-base" }
+init4-bin-base = { git = "https://github.com/init4tech/bin-base.git" }
 
-signet-bundle = { git = "https://github.com/init4tech/signet-sdk", branch = "prestwich/update-trevm" }
-signet-types = { git = "https://github.com/init4tech/signet-sdk", branch = "prestwich/update-trevm" }
-signet-zenith = { git = "https://github.com/init4tech/signet-sdk", branch = "prestwich/update-trevm" }
+signet-bundle = { git = "https://github.com/init4tech/signet-sdk", branch = "main" }
+signet-types = { git = "https://github.com/init4tech/signet-sdk", branch = "main" }
+signet-zenith = { git = "https://github.com/init4tech/signet-sdk", branch = "main" }
 
 alloy = { version = "0.12.6", features = [
     "full",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ path = "bin/submit_transaction.rs"
 [dependencies]
 init4-bin-base = "0.1.0"
 
-zenith-types = "0.13"
+zenith-types = "0.15"
 
-alloy = { version = "0.7.3", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev", "rlp"] }
+alloy = { version = "=0.11.1", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev", "rlp", "node-bindings"] }
 
 aws-config = "1.1.7"
 aws-sdk-kms = "1.15.0"
@@ -48,3 +48,5 @@ tokio = { version = "1.36.0", features = ["full", "macros", "rt-multi-thread"] }
 
 async-trait = "0.1.80"
 oauth2 = "4.4.2"
+metrics = "0.24.1"
+metrics-exporter-prometheus = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,21 @@ name = "transaction-submitter"
 path = "bin/submit_transaction.rs"
 
 [dependencies]
-init4-bin-base = "0.1.0"
+init4-bin-base = { path = "../bin-base" }
 
-zenith-types = "0.15"
+signet-bundle = { git = "https://github.com/init4tech/signet-sdk", branch = "prestwich/update-trevm" }
+signet-types = { git = "https://github.com/init4tech/signet-sdk", branch = "prestwich/update-trevm" }
+signet-zenith = { git = "https://github.com/init4tech/signet-sdk", branch = "prestwich/update-trevm" }
 
-alloy = { version = "=0.11.1", features = ["full", "json-rpc", "signer-aws", "rpc-types-mev", "rlp", "node-bindings"] }
+alloy = { version = "0.12.6", features = [
+    "full",
+    "json-rpc",
+    "signer-aws",
+    "rpc-types-mev",
+    "rlp",
+    "node-bindings",
+    "serde",
+] }
 
 aws-config = "1.1.7"
 aws-sdk-kms = "1.15.0"

--- a/bin/submit_transaction.rs
+++ b/bin/submit_transaction.rs
@@ -83,7 +83,7 @@ async fn connect_from_config() -> (Provider, Address, u64) {
 
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::from(signer))
-        .on_builtin(&rpc_url)
+        .connect(&rpc_url)
         .await
         .unwrap();
 

--- a/bin/submit_transaction.rs
+++ b/bin/submit_transaction.rs
@@ -82,7 +82,6 @@ async fn connect_from_config() -> (Provider, Address, u64) {
     let signer = AwsSigner::new(client, kms_key_id.to_string(), Some(chain_id)).await.unwrap();
 
     let provider = ProviderBuilder::new()
-        .with_recommended_fillers()
         .wallet(EthereumWallet::from(signer))
         .on_builtin(&rpc_url)
         .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ use alloy::{
 };
 use std::{borrow::Cow, env, num, str::FromStr};
 
-use zenith_types::Zenith;
+use signet_zenith::Zenith;
 
 // Keys for .env variables that need to be set to configure the builder.
 const HOST_CHAIN_ID: &str = "HOST_CHAIN_ID";
@@ -207,7 +207,7 @@ impl BuilderConfig {
     /// Connect to the Rollup rpc provider.
     pub async fn connect_ru_provider(&self) -> Result<WalletlessProvider, ConfigError> {
         let provider = ProviderBuilder::new()
-            .on_builtin(&self.ru_rpc_url)
+            .connect(&self.ru_rpc_url)
             .await
             .map_err(ConfigError::Provider)?;
 
@@ -219,7 +219,7 @@ impl BuilderConfig {
         let builder_signer = self.connect_builder_signer().await?;
         let provider = ProviderBuilder::new()
             .wallet(EthereumWallet::from(builder_signer))
-            .on_builtin(&self.host_rpc_url)
+            .connect(&self.host_rpc_url)
             .await
             .map_err(ConfigError::Provider)?;
 
@@ -234,7 +234,7 @@ impl BuilderConfig {
             Vec::with_capacity(self.tx_broadcast_urls.len());
         for url in self.tx_broadcast_urls.iter() {
             let provider =
-                ProviderBuilder::new().on_builtin(url).await.map_err(ConfigError::Provider)?;
+                ProviderBuilder::new().connect(url).await.map_err(ConfigError::Provider)?;
 
             providers.push(provider);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,7 @@ impl ConfigError {
     }
 }
 
-/// Defines a full provider
+/// Defines a full provider.
 pub type Provider = FillProvider<
     JoinFill<
         JoinFill<
@@ -138,7 +138,7 @@ pub type Provider = FillProvider<
     Ethereum,
 >;
 
-/// Defines a read-only wallet
+/// Defines a provider type used to read-only.
 pub type WalletlessProvider = FillProvider<
     JoinFill<
         Identity,
@@ -149,7 +149,7 @@ pub type WalletlessProvider = FillProvider<
 >;
 
 /// Defines a [`Zenith`] instance that is generic over [`Provider`]
-pub type ZenithInstance = Zenith::ZenithInstance<(), Provider, alloy::network::Ethereum>;
+pub type ZenithInstance<P = Provider> = Zenith::ZenithInstance<(), P, alloy::network::Ethereum>;
 
 impl BuilderConfig {
     /// Load the builder configuration from environment variables.
@@ -226,7 +226,7 @@ impl BuilderConfig {
         Ok(provider)
     }
 
-    /// Connect additionally configured non-host providers to broadcast transactions to.
+    /// Connect additional broadcast providers.
     pub async fn connect_additional_broadcast(
         &self,
     ) -> Result<Vec<WalletlessProvider>, ConfigError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,8 @@ use alloy::{
         },
     },
 };
-use std::{borrow::Cow, env, num, str::FromStr};
-
 use signet_zenith::Zenith;
+use std::{borrow::Cow, env, num, str::FromStr};
 
 // Keys for .env variables that need to be set to configure the builder.
 const HOST_CHAIN_ID: &str = "HOST_CHAIN_ID";
@@ -125,7 +124,7 @@ impl ConfigError {
     }
 }
 
-/// Defines a full provider.
+/// Type alias for the provider used in the builder.
 pub type Provider = FillProvider<
     JoinFill<
         JoinFill<
@@ -138,7 +137,7 @@ pub type Provider = FillProvider<
     Ethereum,
 >;
 
-/// Defines a provider type used to read-only.
+/// Type alias for the provider used in the builder, without a wallet.
 pub type WalletlessProvider = FillProvider<
     JoinFill<
         Identity,
@@ -148,7 +147,7 @@ pub type WalletlessProvider = FillProvider<
     Ethereum,
 >;
 
-/// Defines a [`Zenith`] instance that is generic over [`Provider`]
+/// A [`Zenith`] contract instance using [`Provider`] as the provider.
 pub type ZenithInstance<P = Provider> = Zenith::ZenithInstance<(), P, alloy::network::Ethereum>;
 
 impl BuilderConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,4 @@ pub mod tasks;
 pub mod utils;
 
 /// Anonymous crate dependency imports.
-use metrics as _;
-use metrics_exporter_prometheus as _;
 use openssl as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,5 @@ pub mod tasks;
 /// Utilities.
 pub mod utils;
 
-/// Anonymous crate dependency imports.
+// Anonymous import suppresses warnings about unused imports.
 use openssl as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,4 +27,7 @@ pub mod tasks;
 /// Utilities.
 pub mod utils;
 
+/// Anonymous crate dependency imports.
+use metrics as _;
+use metrics_exporter_prometheus as _;
 use openssl as _;

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -9,12 +9,12 @@ use alloy::{
     providers::Provider as _,
     rlp::Buf,
 };
+use signet_bundle::SignetEthBundle;
+use signet_zenith::{Alloy2718Coder, encode_txns};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::OnceLock, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{Instrument, debug, error, info, trace};
-use signet_zenith::{Alloy2718Coder, encode_txns};
-use signet_bundle::SignetEthBundle;
 
 /// Ethereum's slot time in seconds.
 pub const ETHEREUM_SLOT_TIME: u64 = 12;

--- a/src/tasks/block.rs
+++ b/src/tasks/block.rs
@@ -3,7 +3,7 @@ use super::oauth::Authenticator;
 use super::tx_poller::TxPoller;
 use crate::config::{BuilderConfig, WalletlessProvider};
 use alloy::{
-    consensus::{SidecarBuilder, SidecarCoder, TxEnvelope},
+    consensus::{SidecarBuilder, SidecarCoder, transaction::TxEnvelope},
     eips::eip2718::Decodable2718,
     primitives::{B256, Bytes, keccak256},
     providers::Provider as _,
@@ -13,7 +13,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::OnceLock, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{Instrument, debug, error, info, trace};
-use zenith_types::{Alloy2718Coder, ZenithEthBundle, encode_txns};
+use signet_zenith::{Alloy2718Coder, encode_txns};
+use signet_bundle::SignetEthBundle;
 
 /// Ethereum's slot time in seconds.
 pub const ETHEREUM_SLOT_TIME: u64 = 12;
@@ -183,7 +184,7 @@ impl BlockBuilder {
     }
 
     /// Simulates a Zenith bundle against the rollup state
-    async fn simulate_bundle(&mut self, bundle: &ZenithEthBundle) -> eyre::Result<()> {
+    async fn simulate_bundle(&mut self, bundle: &SignetEthBundle) -> eyre::Result<()> {
         // TODO: Simulate bundles with the Simulation Engine
         // [ENG-672](https://linear.app/initiates/issue/ENG-672/add-support-for-bundles)
         debug!(hash = ?bundle.bundle.bundle_hash(), block_number = ?bundle.block_number(), "bundle simulations is not implemented yet - skipping simulation");
@@ -269,7 +270,7 @@ mod tests {
         rpc::types::{TransactionRequest, mev::EthSendBundle},
         signers::local::PrivateKeySigner,
     };
-    use zenith_types::ZenithEthBundle;
+    use signet_bundle::SignetEthBundle;
 
     /// Create a mock bundle for testing with a single transaction
     async fn create_mock_bundle(wallet: &EthereumWallet) -> Bundle {
@@ -294,7 +295,7 @@ mod tests {
             replacement_uuid: Some("replacement_uuid".to_owned()),
         };
 
-        let zenith_bundle = ZenithEthBundle { bundle: eth_bundle, host_fills: None };
+        let zenith_bundle = SignetEthBundle { bundle: eth_bundle, host_fills: None };
 
         Bundle { id: "mock_bundle".to_owned(), bundle: zenith_bundle }
     }

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -16,7 +16,7 @@ pub struct Bundle {
     /// Cache identifier for the bundle
     pub id: String,
     /// The Zenith bundle for this bundle
-    pub bundle: ZenithEthBundle,
+    pub bundle: SignetEthBundle,
 }
 
 /// Response from the tx-pool containing a list of bundles.

--- a/src/tasks/bundler.rs
+++ b/src/tasks/bundler.rs
@@ -8,8 +8,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
 use tokio::time;
 use tracing::{Instrument, debug, trace};
-use zenith_types::ZenithEthBundle;
-
+use signet_bundle::SignetEthBundle;
 /// Holds a bundle from the cache with a unique ID and a Zenith bundle.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Bundle {


### PR DESCRIPTION
# Chore: Updates builder to use signet-sdk 

- adds `bin-base` to builder
- aligns `alloy` to `0.12.6` to match signet ecosystem

Closes ENG-941
Closes ENG-940
