### PR TITLE
refactor: adds block module

### DIFF
--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -1,7 +1,7 @@
 use builder::{
     config::BuilderConfig,
     service::serve_builder,
-    tasks::{block::Simulator, bundler, metrics::MetricsTask, submit::SubmitTask, tx_poller},
+    tasks::{block::sim::Simulator, bundler, metrics::MetricsTask, submit::SubmitTask, tx_poller},
 };
 use init4_bin_base::{deps::tracing, utils::from_env::FromEnv};
 use signet_sim::SimCache;

--- a/src/tasks/block/cfg.rs
+++ b/src/tasks/block/cfg.rs
@@ -1,0 +1,99 @@
+//! This file implements the [`trevm::Cfg`] and [`trevm::Block`] traits for Pecorino blocks.
+use alloy::primitives::{Address, B256, FixedBytes, U256};
+use trevm::{
+    Block,
+    revm::{
+        context::{BlockEnv, CfgEnv},
+        context_interface::block::BlobExcessGasAndPrice,
+        primitives::hardfork::SpecId,
+    },
+};
+
+use crate::config::BuilderConfig;
+
+/// PecorinoCfg holds network-level configuration values.
+#[derive(Debug, Clone, Copy)]
+pub struct PecorinoCfg {}
+
+impl trevm::Cfg for PecorinoCfg {
+    /// Fills the configuration environment with Pecorino-specific values.
+    ///
+    /// # Arguments
+    ///
+    /// - `cfg_env`: The configuration environment to be filled.
+    fn fill_cfg_env(&self, cfg_env: &mut CfgEnv) {
+        let CfgEnv { chain_id, spec, .. } = cfg_env;
+
+        *chain_id = signet_constants::pecorino::RU_CHAIN_ID;
+        *spec = SpecId::default();
+    }
+}
+
+/// PecorinoBlockEnv holds block-level configurations for Pecorino blocks.
+#[derive(Debug, Clone, Copy)]
+pub struct PecorinoBlockEnv {
+    /// The block number for this block.
+    pub number: u64,
+    /// The address the block reward should be sent to.
+    pub beneficiary: Address,
+    /// Timestamp for the block.
+    pub timestamp: u64,
+    /// The gas limit for this block environment.
+    pub gas_limit: u64,
+    /// The basefee to use for calculating gas usage.
+    pub basefee: u64,
+    /// The prevrandao to use for this block.
+    pub prevrandao: Option<FixedBytes<32>>,
+}
+
+/// Implements [`trevm::Block`] for the Pecorino block.
+impl Block for PecorinoBlockEnv {
+    /// Fills the block environment with the Pecorino specific values
+    fn fill_block_env(&self, block_env: &mut BlockEnv) {
+        // Destructure the fields off of the block_env and modify them
+        let BlockEnv {
+            number,
+            beneficiary,
+            timestamp,
+            gas_limit,
+            basefee,
+            difficulty,
+            prevrandao,
+            blob_excess_gas_and_price,
+        } = block_env;
+        *number = self.number;
+        *beneficiary = self.beneficiary;
+        *timestamp = self.timestamp;
+        *gas_limit = self.gas_limit;
+        *basefee = self.basefee;
+        *prevrandao = self.prevrandao;
+
+        // NB: The following fields are set to sane defaults because they
+        // are not supported by the rollup
+        *difficulty = U256::ZERO;
+        *blob_excess_gas_and_price =
+            Some(BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: 0 });
+    }
+}
+
+impl PecorinoBlockEnv {
+    /// Returns a new PecorinoBlockEnv with the specified values.
+    ///
+    /// # Arguments
+    ///
+    /// - config: The BuilderConfig for the builder.
+    /// - number: The block number of this block, usually the latest block number plus 1,
+    ///   unless simulating blocks in the past.
+    /// - timestamp: The timestamp of the block, typically set to the deadline of the
+    ///   block building task.
+    pub fn new(config: BuilderConfig, number: u64, timestamp: u64, basefee: u64) -> Self {
+        PecorinoBlockEnv {
+            number,
+            beneficiary: config.builder_rewards_address,
+            timestamp,
+            gas_limit: config.rollup_block_gas_limit,
+            basefee,
+            prevrandao: Some(B256::random()),
+        }
+    }
+}

--- a/src/tasks/block/mod.rs
+++ b/src/tasks/block/mod.rs
@@ -1,4 +1,4 @@
-//! block holds the tasks responsible for block environment configuration, 
+//! block holds the tasks responsible for block environment configuration,
 //! preparation, and simulation.
 
 /// Block simulation task for building blocks.

--- a/src/tasks/block/mod.rs
+++ b/src/tasks/block/mod.rs
@@ -1,0 +1,8 @@
+//! block holds the tasks responsible for block environment configuration, 
+//! preparation, and simulation.
+
+/// Block simulation task for building blocks.
+pub mod sim;
+
+/// Block environment configuration for the builder.
+pub mod cfg;

--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -1,15 +1,15 @@
 //! `block.rs` contains the Simulator and everything that wires it into an
 //! actor that handles the simulation of a stream of bundles and transactions
 //! and turns them into valid Pecorino blocks for network submission.
+use super::cfg::PecorinoBlockEnv;
 use crate::{
     config::{BuilderConfig, RuProvider},
-    tasks::bundler::Bundle,
+    tasks::{block::cfg::PecorinoCfg, bundler::Bundle},
 };
 use alloy::{
     consensus::TxEnvelope,
     eips::{BlockId, BlockNumberOrTag::Latest},
     network::Ethereum,
-    primitives::{Address, B256, FixedBytes, U256},
     providers::Provider,
 };
 use chrono::{DateTime, Utc};
@@ -33,15 +33,9 @@ use tokio::{
     task::JoinHandle,
     time::sleep,
 };
-use trevm::{
-    Block,
-    revm::{
-        context::{BlockEnv, CfgEnv},
-        context_interface::block::BlobExcessGasAndPrice,
-        database::{AlloyDB, WrapDatabaseAsync},
-        inspector::NoOpInspector,
-        primitives::hardfork::SpecId::{self},
-    },
+use trevm::revm::{
+    database::{AlloyDB, WrapDatabaseAsync},
+    inspector::NoOpInspector,
 };
 
 /// `Simulator` is responsible for periodically building blocks and submitting them for
@@ -406,93 +400,6 @@ async fn cache_updater(
                     cache.add_item(bundle.bundle, p);
                 }
             }
-        }
-    }
-}
-
-/// PecorinoCfg holds network-level configuration values.
-#[derive(Debug, Clone, Copy)]
-pub struct PecorinoCfg {}
-
-impl trevm::Cfg for PecorinoCfg {
-    /// Fills the configuration environment with Pecorino-specific values.
-    ///
-    /// # Arguments
-    ///
-    /// - `cfg_env`: The configuration environment to be filled.
-    fn fill_cfg_env(&self, cfg_env: &mut CfgEnv) {
-        let CfgEnv { chain_id, spec, .. } = cfg_env;
-
-        *chain_id = signet_constants::pecorino::RU_CHAIN_ID;
-        *spec = SpecId::default();
-    }
-}
-
-/// PecorinoBlockEnv holds block-level configurations for Pecorino blocks.
-#[derive(Debug, Clone, Copy)]
-pub struct PecorinoBlockEnv {
-    /// The block number for this block.
-    pub number: u64,
-    /// The address the block reward should be sent to.
-    pub beneficiary: Address,
-    /// Timestamp for the block.
-    pub timestamp: u64,
-    /// The gas limit for this block environment.
-    pub gas_limit: u64,
-    /// The basefee to use for calculating gas usage.
-    pub basefee: u64,
-    /// The prevrandao to use for this block.
-    pub prevrandao: Option<FixedBytes<32>>,
-}
-
-/// Implements [`trevm::Block`] for the Pecorino block.
-impl Block for PecorinoBlockEnv {
-    /// Fills the block environment with the Pecorino specific values
-    fn fill_block_env(&self, block_env: &mut trevm::revm::context::BlockEnv) {
-        // Destructure the fields off of the block_env and modify them
-        let BlockEnv {
-            number,
-            beneficiary,
-            timestamp,
-            gas_limit,
-            basefee,
-            difficulty,
-            prevrandao,
-            blob_excess_gas_and_price,
-        } = block_env;
-        *number = self.number;
-        *beneficiary = self.beneficiary;
-        *timestamp = self.timestamp;
-        *gas_limit = self.gas_limit;
-        *basefee = self.basefee;
-        *prevrandao = self.prevrandao;
-
-        // NB: The following fields are set to sane defaults because they
-        // are not supported by the rollup
-        *difficulty = U256::ZERO;
-        *blob_excess_gas_and_price =
-            Some(BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: 0 });
-    }
-}
-
-impl PecorinoBlockEnv {
-    /// Returns a new PecorinoBlockEnv with the specified values.
-    ///
-    /// # Arguments
-    ///
-    /// - config: The BuilderConfig for the builder.
-    /// - number: The block number of this block, usually the latest block number plus 1,
-    ///   unless simulating blocks in the past.
-    /// - timestamp: The timestamp of the block, typically set to the deadline of the
-    ///   block building task.
-    fn new(config: BuilderConfig, number: u64, timestamp: u64, basefee: u64) -> Self {
-        PecorinoBlockEnv {
-            number,
-            beneficiary: config.builder_rewards_address,
-            timestamp,
-            gas_limit: config.rollup_block_gas_limit,
-            basefee,
-            prevrandao: Some(B256::random()),
         }
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,6 +1,3 @@
-/// Block creation task
-pub mod block;
-
 /// Bundle poller task
 pub mod bundler;
 
@@ -15,3 +12,6 @@ pub mod submit;
 
 /// Tx polling task
 pub mod tx_poller;
+
+/// Block simulation and environment
+pub mod block;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,5 +1,5 @@
 //! Test utilities for testing builder tasks
-use crate::{config::BuilderConfig, tasks::block::PecorinoBlockEnv};
+use crate::{config::BuilderConfig, tasks::block::cfg::PecorinoBlockEnv};
 use alloy::{
     consensus::{SignableTransaction, TxEip1559, TxEnvelope},
     primitives::{Address, FixedBytes, TxKind, U256},
@@ -32,7 +32,6 @@ pub fn setup_test_config() -> Result<BuilderConfig> {
         sequencer_key: None,
         builder_key: "0000000000000000000000000000000000000000000000000000000000000000".into(),
         block_confirmation_buffer: 1,
-
         builder_rewards_address: Address::default(),
         rollup_block_gas_limit: 3_000_000_000,
         tx_pool_url: "http://localhost:9000/".into(),

--- a/tests/block_builder_test.rs
+++ b/tests/block_builder_test.rs
@@ -9,7 +9,7 @@ mod tests {
         signers::local::PrivateKeySigner,
     };
     use builder::{
-        tasks::block::Simulator,
+        tasks::block::sim::Simulator,
         test_utils::{new_signed_tx, setup_logging, setup_test_config, test_block_env},
     };
     use init4_bin_base::utils::calc::SlotCalculator;


### PR DESCRIPTION
This PR refactors the block task into a module to prepare for separating block env preparation from simulation logic. 