### PR TITLE
fix: continue instead of break in the submit task loop

### DIFF
--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -286,7 +286,7 @@ impl SubmitTask {
             };
 
             if self.retrying_handle_inbound(&block, 3).await.is_err() {
-                break;
+                continue;
             }
         }
     }


### PR DESCRIPTION
# fix: continue instead of break in the submit task loop

This PR makes the submit task future `continue` instead of `break` when it is done finishing its retry loop.
It was incorrectly breaking out of its submit loop after finishing one `retrying_handle_inbound` call.

Fixes ENG-1077

