### PR TITLE
chore: adds foundry to rust tests

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -5,12 +5,11 @@ on:
     branches: [main]
   pull_request:
 
-# simplest example of using the rust-base action
 jobs:
   rust-base:
     uses: init4tech/actions/.github/workflows/rust-base.yml@main
     with: 
       requires-private-deps: true
+      install-foundry: true
     secrets: 
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ path = "bin/builder.rs"
 name = "transaction-submitter"
 path = "bin/submit_transaction.rs"
 
+[features]
+integration = []
+
 [dependencies]
 init4-bin-base = "0.3"
 

--- a/tests/block_builder_test.rs
+++ b/tests/block_builder_test.rs
@@ -26,7 +26,7 @@ mod tests {
     /// This test sets up a simulated environment using Anvil, creates a block builder,
     /// and verifies that the block builder can successfully build a block containing
     /// transactions from multiple senders.
-    #[ignore = "integration test"]
+    #[cfg(feature = "integration")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_handle_build() {
         setup_logging();


### PR DESCRIPTION
This PR sets an input boolean to install Foundry in the Rust action and sets up the integration test feature so that block simulation tests pass.



