### PR TITLE
fix: submit channel refactors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ integration = []
 [dependencies]
 init4-bin-base = { version = "0.4.1", features = ["perms"] }
 
-signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "bd183b627dcb0eb682da801093b13f1f8311446b" }
-signet-sim = { git = "https://github.com/init4tech/signet-sdk", rev = "bd183b627dcb0eb682da801093b13f1f8311446b" }
-signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk", rev = "bd183b627dcb0eb682da801093b13f1f8311446b" }
-signet-types = { git = "https://github.com/init4tech/signet-sdk", rev = "bd183b627dcb0eb682da801093b13f1f8311446b" }
-signet-zenith = { git = "https://github.com/init4tech/signet-sdk", rev = "bd183b627dcb0eb682da801093b13f1f8311446b" }
+signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
+signet-sim = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
+signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
+signet-types = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
+signet-zenith = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
 
 trevm = { version = "0.23.4", features = ["concurrent-db", "test-utils"] }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,8 +72,9 @@ pub struct BuilderConfig {
     /// NOTE: should not include the host_rpc_url value
     #[from_env(
         var = "TX_BROADCAST_URLS",
-        desc = "Additional RPC URLs to which to broadcast transactions",
-        infallible
+        desc = "Additional RPC URLs to which the builder broadcasts transactions",
+        infallible,
+        optional
     )]
     pub tx_broadcast_urls: Vec<Cow<'static, str>>,
     /// address of the Zenith contract on Host.

--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -82,7 +82,7 @@ impl Simulator {
         block: BlockEnv,
     ) -> eyre::Result<BuiltBlock> {
         let db = self.create_db().await.unwrap();
-        let number = block.number;
+        
         let block_build: BlockBuild<_, NoOpInspector> = BlockBuild::new(
             db,
             constants,
@@ -94,9 +94,8 @@ impl Simulator {
             self.config.rollup_block_gas_limit,
         );
 
-        let mut built_block = block_build.build().await;
-        built_block.set_block_number(number);
-        debug!(block = ?built_block, "finished block simulation");
+        let built_block = block_build.build().await;
+        debug!(block_number = ?built_block.block_number(), "finished building block");
 
         Ok(built_block)
     }

--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -82,7 +82,7 @@ impl Simulator {
         block: BlockEnv,
     ) -> eyre::Result<BuiltBlock> {
         let db = self.create_db().await.unwrap();
-        
+
         let block_build: BlockBuild<_, NoOpInspector> = BlockBuild::new(
             db,
             constants,

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -21,7 +21,7 @@ use init4_bin_base::deps::{
 use signet_sim::BuiltBlock;
 use signet_types::{SignRequest, SignResponse};
 use signet_zenith::{
-    BundleHelper::{self, submitCall, BlockHeader, FillPermit2},
+    BundleHelper::{self, BlockHeader, FillPermit2, submitCall},
     Zenith::{self, IncorrectHostBlock},
 };
 use std::time::{Instant, UNIX_EPOCH};
@@ -32,7 +32,7 @@ pub const BASE_FEE_PER_GAS: u128 = 10 * GWEI_TO_WEI as u128;
 /// Base max priority fee per gas to use as a starting point for retry bumps
 pub const BASE_MAX_PRIORITY_FEE_PER_GAS: u128 = 2 * GWEI_TO_WEI as u128;
 /// Base maximum fee per blob gas to use as a starting point for retry bumps
-pub const BASE_MAX_FEE_PER_BLOB_GAS: u128 = 1 * GWEI_TO_WEI as u128;
+pub const BASE_MAX_FEE_PER_BLOB_GAS: u128 = GWEI_TO_WEI as u128;
 
 macro_rules! spawn_provider_send {
     ($provider:expr, $tx:expr) => {

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -60,7 +60,7 @@ pub enum ControlFlow {
 }
 
 /// Submits sidecars in ethereum txns to mainnet ethereum
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SubmitTask {
     /// Zenith
     pub zenith: ZenithInstance,

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -435,7 +435,7 @@ impl SubmitTask {
     }
 }
 
-// Returns gas parameters based on retry counts. This uses
+// Returns gas parameters based on retry counts.
 fn calculate_gas_limits(
     retry_count: usize,
     base_max_fee_per_gas: u128,


### PR DESCRIPTION
# fix: submit channel refactors

This PR includes several fixes and refactors to the channel submission logic. 

- Handle 403 errors with `Skip`s instead of erroring
- Adds `retry_count` increments to some code paths that weren't previously ticking the count
- Adds per-slot limiting to the block building loop so that the retry function doesn't simply get called again after 3 attempts
- Explicitly logs the `call` results of the blob transaction to aid with debugging
- Adds gas bumping logic to the submit task to facilitate transaction replacement

Additionally, there are some configuration changes that needed to be made.

- Additional broadcast hosts was just pointing back at the host RPC, which was adding noise to the logs and interfering with nonce debugging. This PR makes it optional and un-sets the duplicate host-rpc URL.
- Slot offset and start timestamp were incorrectly configured and have been updated to their correct values

Closes ENG-1079

See: [Builder Retry Logic](https://www.notion.so/init4tech/Builder-Retry-Logic-1f43e1cd45398092a1b3fb692dd37787?pvs=4)