### PR TITLE
chore: sets signet-sdk dependency back to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "bin/submit_transaction.rs"
 integration = []
 
 [dependencies]
-init4-bin-base = { version = "0.4.1", features = ["perms"] }
+init4-bin-base = { version = "0.4.2", features = ["perms"] }
 
 signet-constants = { git = "https://github.com/init4tech/signet-sdk" }
 signet-sim = { git = "https://github.com/init4tech/signet-sdk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ integration = []
 [dependencies]
 init4-bin-base = { version = "0.4.1", features = ["perms"] }
 
-signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
-signet-sim = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
-signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
-signet-types = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
-signet-zenith = { git = "https://github.com/init4tech/signet-sdk", rev = "ba5894f6fac35299d495ae115cd465a1f0791637" }
+signet-constants = { git = "https://github.com/init4tech/signet-sdk" }
+signet-sim = { git = "https://github.com/init4tech/signet-sdk" }
+signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk" }
+signet-types = { git = "https://github.com/init4tech/signet-sdk" }
+signet-zenith = { git = "https://github.com/init4tech/signet-sdk" }
 
 trevm = { version = "0.23.4", features = ["concurrent-db", "test-utils"] }
 
@@ -43,6 +43,7 @@ alloy = { version = "1.0.5", features = [
     "rlp",
     "node-bindings",
     "serde",
+    "getrandom"
 ] }
 
 serde = { version = "1.0.197", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ integration = []
 [dependencies]
 init4-bin-base = { version = "0.4.2", features = ["perms"] }
 
-signet-constants = { git = "https://github.com/init4tech/signet-sdk" }
-signet-sim = { git = "https://github.com/init4tech/signet-sdk" }
-signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk" }
-signet-types = { git = "https://github.com/init4tech/signet-sdk" }
-signet-zenith = { git = "https://github.com/init4tech/signet-sdk" }
+signet-constants = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
+signet-sim = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
+signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
+signet-types = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
+signet-zenith = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
 
 trevm = { version = "0.23.4", features = ["concurrent-db", "test-utils"] }
 
@@ -58,3 +58,4 @@ tokio = { version = "1.36.0", features = ["full", "macros", "rt-multi-thread"] }
 oauth2 = "5"
 tokio-stream = "0.1.17"
 url = "2.5.4"
+tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ integration = []
 [dependencies]
 init4-bin-base = { version = "0.4.2", features = ["perms"] }
 
-signet-constants = { git = "https://github.com/init4tech/signet-sdk" }
-signet-sim = { git = "https://github.com/init4tech/signet-sdk" }
-signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk" }
-signet-types = { git = "https://github.com/init4tech/signet-sdk" }
-signet-zenith = { git = "https://github.com/init4tech/signet-sdk" }
+signet-constants = { git = "https://github.com/init4tech/signet-sdk", branch = "main" }
+signet-sim = { git = "https://github.com/init4tech/signet-sdk", branch = "main" }
+signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk", branch = "main" }
+signet-types = { git = "https://github.com/init4tech/signet-sdk", branch = "main" }
+signet-zenith = { git = "https://github.com/init4tech/signet-sdk", branch = "main" }
 
 trevm = { version = "0.23.4", features = ["concurrent-db", "test-utils"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ integration = []
 [dependencies]
 init4-bin-base = { version = "0.4.2", features = ["perms"] }
 
-signet-constants = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
-signet-sim = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
-signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
-signet-types = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
-signet-zenith = { git = "https://github.com/init4tech/signet-sdk", branch = "dylan/logging" }
+signet-constants = { git = "https://github.com/init4tech/signet-sdk" }
+signet-sim = { git = "https://github.com/init4tech/signet-sdk" }
+signet-tx-cache = { git = "https://github.com/init4tech/signet-sdk" }
+signet-types = { git = "https://github.com/init4tech/signet-sdk" }
+signet-zenith = { git = "https://github.com/init4tech/signet-sdk" }
 
 trevm = { version = "0.23.4", features = ["concurrent-db", "test-utils"] }
 

--- a/src/quincey.rs
+++ b/src/quincey.rs
@@ -1,7 +1,7 @@
 use alloy::signers::Signer;
 use eyre::bail;
 use init4_bin_base::{
-    deps::tracing::{self, debug, info, instrument, trace},
+    deps::tracing::{debug, info, instrument, trace},
     perms::SharedToken,
     utils::signer::LocalOrAws,
 };

--- a/src/tasks/submit.rs
+++ b/src/tasks/submit.rs
@@ -16,7 +16,7 @@ use alloy::{
 use eyre::bail;
 use init4_bin_base::deps::{
     metrics::{counter, histogram},
-    tracing::{self, Instrument, debug, debug_span, error, info, instrument, warn},
+    tracing::{Instrument, debug, debug_span, error, info, instrument, warn},
 };
 use signet_sim::BuiltBlock;
 use signet_types::{SignRequest, SignResponse};
@@ -221,7 +221,7 @@ impl SubmitTask {
 
         // Extract fills from the built block
         let fills = self.extract_fills(block);
-        debug!(?fills, "extracted fills");
+        debug!(fill_count = fills.len(), "extracted fills");
 
         // Create a blob transaction with the blob header and signature values and return it
         let tx = self


### PR DESCRIPTION
# chore: sets dependency back to latest 

- sets the `signet-sdk` dependency back to using latest by removing the previously-set rev hash. 
