### PR TITLE
chore: bump builder to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "builder"
-version = "0.1.1"
+version = "0.2.0"
 description = "signet builder example"
 
 edition = "2024"


### PR DESCRIPTION
# bump builder to v0.2.0

This PR bumps the `builder` crate version  to `0.2.0`.

Closes ENG-1038