### PR TITLE
fix(sim): use previous block number for creating alloy db in simulator

### DIFF
--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -102,7 +102,8 @@ impl Simulator {
         debug!(block_number = block_env.number, tx_count = sim_items.len(), "starting block build",);
         let concurrency_limit = self.config.concurrency_limit();
 
-        let db = self.create_db(block_env.number).unwrap();
+        // NB: Build AlloyDB from the previous block number's state, since block_env maps to the in-progress block
+        let db = self.create_db(block_env.number - 1).unwrap();
 
         let block_build: BlockBuild<_, NoOpInspector> = BlockBuild::new(
             db,


### PR DESCRIPTION
- Commit `6499785` introduced a logic change that used the block number
  from the `block_env` to fetch the state for the alloy DB instance,
  which results in querying for state of a block number that doesn't exist.
- This commit reduces that number by 1 to correctly create the AlloyDB
  state from the previous block instead of the in-progress block.