### PR TITLE
fix(sim): shorten simulation deadline

### DIFF
--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -217,7 +217,7 @@ impl Simulator {
 
         // We add a 1500 ms buffer to account for sequencer stopping signing.
         let deadline =
-            Instant::now() + Duration::from_secs(remaining) - Duration::from_millis(1500);
+            Instant::now() + Duration::from_secs(remaining) - Duration::from_millis(2500);
 
         deadline.max(Instant::now())
     }


### PR DESCRIPTION
We need to take into account that Quincey stops signing 2s before the end of the slot. We were not doing this correctly before.