### PR TITLE
fix: properly calculate deadline, use `chrono` for calculating timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ version = "0.2.0"
 dependencies = [
  "alloy",
  "axum 0.7.9",
+ "chrono",
  "eyre",
  "init4-bin-base",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.11.24", features = ["blocking", "json"] }
 serde_json = "1.0"
 tokio = { version = "1.36.0", features = ["full", "macros", "rt-multi-thread"] }
+chrono = "0.4.40"
 
 tokio-stream = "0.1.17"
 url = "2.5.4"

--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -214,11 +214,11 @@ impl Simulator {
 
         // We have the timepoint in seconds into the slot. To find out what's
         // remaining, we need to subtract it from the slot duration
-        let remaining = self.slot_calculator().slot_duration() - timepoint;
+        // we also subtract 3 seconds to account for the sequencer stopping signing.
+        let remaining = (self.slot_calculator().slot_duration() - timepoint).saturating_sub(3);
 
         // We add a 2500 ms buffer to account for sequencer stopping signing.
-        let deadline =
-            Instant::now() + Duration::from_secs(remaining) - Duration::from_millis(2500);
+        let deadline = Instant::now() + Duration::from_secs(remaining);
 
         debug!(
             timepoint,

--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -217,14 +217,12 @@ impl Simulator {
         // we also subtract 3 seconds to account for the sequencer stopping signing.
         let remaining = (self.slot_calculator().slot_duration() - timepoint).saturating_sub(3);
 
-        // We add a 2500 ms buffer to account for sequencer stopping signing.
         let deadline = Instant::now() + Duration::from_secs(remaining);
 
         debug!(
             timepoint,
             remaining,
-            timestamp = chrono::Utc::now().timestamp(),
-            deadline = ?deadline,
+            timestamp = crate::utils::now(),
             "calculated deadline for block simulation"
         );
 

--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -220,6 +220,14 @@ impl Simulator {
         let deadline =
             Instant::now() + Duration::from_secs(remaining) - Duration::from_millis(2500);
 
+        debug!(
+            timepoint,
+            remaining,
+            timestamp = chrono::Utc::now().timestamp(),
+            deadline = ?deadline,
+            "calculated deadline for block simulation"
+        );
+
         deadline.max(Instant::now())
     }
 

--- a/src/tasks/submit/task.rs
+++ b/src/tasks/submit/task.rs
@@ -171,7 +171,7 @@ impl SubmitTask {
                 .send_transaction(req)
                 .instrument(span.clone())
                 .await
-                .inspect_err(|e| error!(error = %e, "sending transaction"))
+                .inspect_err(|e| error!(error = %e, "error sending transaction"))
                 .unwrap_or(ControlFlow::Retry);
 
             let guard = span.entered();

--- a/src/tasks/submit/task.rs
+++ b/src/tasks/submit/task.rs
@@ -160,7 +160,7 @@ impl SubmitTask {
                 expected_slot,
                 start = window.start,
                 end = window.end,
-                now = utils::now(),
+                unix_now = utils::now(),
             );
 
             // Check at the top of the loop if the slot is still valid. This

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,12 +6,10 @@ use alloy::{
 };
 use signet_sim::BuiltBlock;
 use signet_zenith::BundleHelper::FillPermit2;
-use std::time::UNIX_EPOCH;
 
 /// Returns the current timestamp in seconds since the UNIX epoch.
 pub(crate) fn now() -> u64 {
-    let now = std::time::SystemTime::now();
-    now.duration_since(UNIX_EPOCH).unwrap().as_secs()
+    chrono::Utc::now().timestamp() as u64
 }
 
 // This function converts &[SignedFill] into [FillPermit2]


### PR DESCRIPTION
We were calculating the deadline by subtracting from an `Instant::now()`, which we shouldn't do. We now simply subtract the buffer from the remaining time in the slot and add the result to the current instant instead.

This also switches to using `chrono` for anything regarding timestamps instead of using `std`, for parity with the slot calculator. Everything else uses `Instant` or `Duration` already.

Closes ENG-1167
Closes ENG-1019