### PR TITLE
feat: add a couple checks to the env task

### DIFF
--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -26,9 +26,11 @@ async fn main() -> eyre::Result<()> {
     // RU WS connection is invalid.
     let (ru_provider, host_provider) =
         tokio::try_join!(config.connect_ru_provider(), config.connect_host_provider(),)?;
+    let quincey = config.connect_quincey().await?;
 
     // Spawn the EnvTask
-    let env_task = EnvTask::new(config.clone(), host_provider.clone(), ru_provider.clone());
+    let env_task =
+        EnvTask::new(config.clone(), host_provider.clone(), quincey, ru_provider.clone());
     let (block_env, env_jh) = env_task.spawn();
 
     // Spawn the cache system

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,6 +26,14 @@ macro_rules! span_info {
 
 /// Helper macro to log a warning event within a span that is not currently
 /// entered.
+macro_rules! span_warn {
+    ($span:expr, $($arg:tt)*) => {
+        span_scoped!($span, warn!($($arg)*))
+    };
+}
+
+/// Helper macro to log a warning event within a span that is not currently
+/// entered.
 macro_rules! span_error {
     ($span:expr, $($arg:tt)*) => {
         span_scoped!($span, error!($($arg)*))
@@ -34,7 +42,7 @@ macro_rules! span_error {
 
 /// Helper macro to unwrap a result or continue the loop with a tracing event.
 macro_rules! res_unwrap_or_continue {
-    ($result:expr, $span:expr, $level:ident!($($arg:tt)*)) => {
+    ($result:expr, $span:expr, $level:ident!($($arg:tt)*) $(,)?) => {
         match $result {
             Ok(value) => value,
             Err(err) => {

--- a/tests/block_builder_test.rs
+++ b/tests/block_builder_test.rs
@@ -43,8 +43,11 @@ async fn test_handle_build() {
     let ru_provider = RootProvider::<Ethereum>::new_http(anvil_instance.endpoint_url());
     let host_provider = config.connect_host_provider().await.unwrap();
 
+    // Create a quincey client
+    let quincey = config.connect_quincey().await.unwrap();
+
     let block_env =
-        EnvTask::new(config.clone(), host_provider.clone(), ru_provider.clone()).spawn().0;
+        EnvTask::new(config.clone(), host_provider.clone(), quincey, ru_provider.clone()).spawn().0;
 
     let block_builder =
         Simulator::new(&config, host_provider.clone(), ru_provider.clone(), block_env);

--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -15,6 +15,7 @@ async fn test_bundle_poller_roundtrip() -> eyre::Result<()> {
     let (block_env, _jh) = EnvTask::new(
         config.clone(),
         config.connect_host_provider().await?,
+        config.connect_quincey().await?,
         config.connect_ru_provider().await?,
     )
     .spawn();

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -9,9 +9,11 @@ async fn test_bundle_poller_roundtrip() -> eyre::Result<()> {
     setup_logging();
 
     let config = setup_test_config().unwrap();
+
     let (mut env_watcher, _jh) = EnvTask::new(
         config.clone(),
         config.connect_host_provider().await?,
+        config.connect_quincey().await?,
         config.connect_ru_provider().await?,
     )
     .spawn();


### PR DESCRIPTION
Adds two checks to the env task
- rollup and host have the same timestamp (sanity check to prevent slot shenanigans)
- quincey is willing to sign