### PR TITLE
chore(config): make flashbots URL not optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,7 @@ pub struct BuilderConfig {
         var = "FLASHBOTS_ENDPOINT",
         desc = "Flashbots endpoint for privately submitting Signet bundles"
     )]
-    pub flashbots_endpoint: Option<url::Url>,
+    pub flashbots_endpoint: url::Url,
 
     /// URL for remote Quincey Sequencer server to sign blocks.
     /// NB: Disregarded if a sequencer_signer is configured.
@@ -219,11 +219,9 @@ impl BuilderConfig {
         &self,
         config: &BuilderConfig,
     ) -> Result<FlashbotsProvider, eyre::Error> {
-        let endpoint =
-            config.flashbots_endpoint.clone().expect("flashbots endpoint must be configured");
         let signer = config.connect_builder_signer().await?;
         let flashbots: FlashbotsProvider =
-            ProviderBuilder::new().wallet(signer).connect_http(endpoint);
+            ProviderBuilder::new().wallet(signer).connect_http(config.flashbots_endpoint.clone());
         Ok(flashbots)
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -32,7 +32,7 @@ pub fn setup_test_config() -> Result<BuilderConfig> {
             .unwrap()
             .try_into()
             .unwrap(),
-        flashbots_endpoint: Some("https://relay-sepolia.flashbots.net:443".parse().unwrap()),
+        flashbots_endpoint: "https://relay-sepolia.flashbots.net:443".parse().unwrap(),
         quincey_url: "http://localhost:8080".into(),
         sequencer_key: None,
         builder_key: env::var("SEPOLIA_ETH_PRIV_KEY")


### PR DESCRIPTION
No reason to have this optional, probably vestigial from when we had multiple submit tasks.