### PR TITLE
fix(env): Preflight check for current-block being built (next), not latest block

### DIFF
--- a/src/tasks/env.rs
+++ b/src/tasks/env.rs
@@ -278,7 +278,9 @@ impl EnvTask {
 
             let (host_block_res, quincey_res) = tokio::join!(
                 self.host_provider.get_block_by_number(host_block_number.into()),
-                self.quincey.preflight_check(&self.config.constants, host_block_number)
+                // We want to check that we're able to sign for the block we're gonna start building.
+                // If not, we just want to skip all the work.
+                self.quincey.preflight_check(&self.config.constants, host_block_number + 1)
             );
 
             res_unwrap_or_continue!(


### PR DESCRIPTION
We should be checking for latest block + 1 (block the builder wants to build), not the latest block that has landed in the chain.

Closes ENG-1570