### PR TITLE
chore(ci): remove unneeded ssh private key argument

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,8 +8,5 @@ on:
 jobs:
   rust-base:
     uses: init4tech/actions/.github/workflows/rust-base.yml@main
-    with: 
-      requires-private-deps: true
+    with:
       install-foundry: true
-    secrets: 
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
We currently have no private dependencies that require this. This was a very old necessity due to previously unreleased node code.

Closes ENG-1797.