### PR TITLE
ci: add flashbots integration tests to CI

### DIFF
--- a/.github/workflows/flashbots-ci.yml
+++ b/.github/workflows/flashbots-ci.yml
@@ -1,9 +1,12 @@
 name: Flashbots Integration Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to test (branch, tag, or SHA)'
+        required: false
+        default: 'main'
 
 jobs:
   flashbots-tests:
@@ -13,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/flashbots-ci.yml
+++ b/.github/workflows/flashbots-ci.yml
@@ -1,0 +1,25 @@
+name: Flashbots Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  flashbots-tests:
+    name: Flashbots Integration Tests
+    runs-on:
+      group: init4-runners
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Optional Foundry Install
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Run flashbots integration tests
+        run: make test-flashbots

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # Usage:
-#   make            # build (debug)
-#   make run        # cargo run (debug)
-#   make release    # optimized build
-#   make test       # run unit + integration tests
-#   make fmt        # check & auto‑format
-#   make clippy     # full‑feature lint, deny warnings
-#   make doc        # build docs
-#   make clean      # remove target dir
+#   make                 # build (debug)
+#   make run             # cargo run (debug)
+#   make release         # optimized build
+#   make test            # run unit + integration tests
+#   make test-flashbots  # run flashbots integration tests (ignored tests)
+#   make fmt             # check & auto‑format
+#   make clippy          # full‑feature lint, deny warnings
+#   make doc             # build docs
+#   make clean           # remove target dir
 # ----------------------------------------------------
 
 CARGO        ?= cargo
@@ -16,7 +17,7 @@ PROFILE      ?= dev             # override with `make PROFILE=release build`
 CLIPPY_FLAGS ?= $(TARGETS) $(FEATURES) --workspace --profile dev -- -D warnings
 FMT_FLAGS    ?= --all
 
-.PHONY: build release run test clean fmt clippy default
+.PHONY: build release run test test-flashbots clean fmt clippy default
 
 default: build
 
@@ -33,6 +34,9 @@ run:
 
 test:
 	$(CARGO) test
+
+test-flashbots:
+	cargo nextest run --run-ignored=only --workspace
 
 clean:
 	$(CARGO) clean


### PR DESCRIPTION
## Summary

Adds `make test-flashbots` command to the Builder CI pipeline.

## Changes

- **Makefile**: Added `test-flashbots` target that runs `cargo nextest run --run-ignored=only --workspace` to execute all ignored integration tests
- **flashbots-ci.yml**: New GitHub Actions workflow that runs the flashbots integration tests on pushes to main and PRs

## Testing

The workflow installs cargo-nextest and Foundry, then runs the integration tests that are currently marked with `#[ignore]` annotations.

Closes [ENG-1300](https://linear.app/init4/issue/ENG-1300/add-ci-test-that-runs-flashbots-integration-tests)