### PR TITLE
fix: retry fetching the host block header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,6 +2029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
+ "gloo-timers 0.3.0",
  "tokio",
 ]
 
@@ -2422,6 +2423,7 @@ dependencies = [
  "alloy-chains",
  "alloy-hardforks 0.4.7",
  "axum 0.7.9",
+ "backon",
  "eyre",
  "futures-util",
  "init4-bin-base",
@@ -4097,7 +4099,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "send_wrapper 0.4.0",
 ]
 
@@ -4230,6 +4232,18 @@ name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,16 +47,17 @@ alloy = { version = "1.4.0", features = [
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
 
 axum = "0.7.5"
+backon = { version = "1.6.0", features = ["tokio-sleep"] }
 eyre = "0.6.12"
+futures-util = "0.3.31"
 openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.12.22", features = ["blocking", "json"] }
 serde = { version = "1.0.197", features = ["derive"] }
-tracing = "0.1.41"
+thiserror = "2.0.17"
 tokio = { version = "1.36.0", features = ["full", "macros", "rt-multi-thread"] }
 tokio-stream = "0.1.17"
+tracing = "0.1.41"
 url = "2.5.4"
-thiserror = "2.0.17"
-futures-util = "0.3.31"
 
 [dev-dependencies]
 alloy-hardforks = "0.4.0"


### PR DESCRIPTION
This adds retries when fetching the host block in the `EnvTask`.

Without this, a single failure will cause a builder to skip building for a given block. If the host RPC is a little behind the rollup, we have a race condition causing skipped blocks.

I also changed the RPC to fetch just the header rather than the full block.