### PR TITLE
fix: actually retry fetching host block header

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -52,16 +52,3 @@ macro_rules! res_unwrap_or_continue {
         }
     };
 }
-
-/// Helper macro to unwrap an option or continue the loop with a tracing event.
-macro_rules! opt_unwrap_or_continue {
-    ($option:expr, $span:expr, $level:ident!($($arg:tt)*)) => {
-        match $option {
-            Some(value) => value,
-            None => {
-                span_scoped!($span, $level!($($arg)*));
-                continue;
-            }
-        }
-    };
-}


### PR DESCRIPTION
The previous fix skipped retrying if the RPC server returned `Ok(None)`, which is wrong for the most likely case of the server lagging slightly.

This now converts `Ok(None)` to an error so retrying is attempted.