### PR TITLE
fix: run block simulation on dedicated tokio runtime

### DIFF
--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -14,6 +14,7 @@ use signet_sim::{BlockBuild, BuiltBlock, SimCache};
 use signet_types::constants::SignetSystemConstants;
 use std::time::{Duration, Instant};
 use tokio::{
+    runtime::Runtime,
     sync::{
         mpsc::{self},
         watch,
@@ -138,6 +139,7 @@ impl SimulatorTask {
         sim_items: SimCache,
         finish_by: Instant,
         sim_env: &SimEnv,
+        sim_rt: &Runtime,
     ) -> eyre::Result<BuiltBlock> {
         let concurrency_limit = self.config.concurrency_limit();
 
@@ -154,7 +156,12 @@ impl SimulatorTask {
             self.config.max_host_gas(sim_env.prev_host().gas_limit),
         );
 
-        let built_block = block_build.build().in_current_span().await;
+        // Spawn the CPU-heavy EVM simulation on the dedicated runtime so it
+        // cannot starve the main tokio runtime (healthcheck, cache I/O, etc.).
+        let built_block = sim_rt
+            .spawn(block_build.build().in_current_span())
+            .await
+            .map_err(|e| eyre::eyre!("simulation task panicked: {e}"))?;
         debug!(
             tx_count = built_block.tx_count(),
             block_number = built_block.block_number(),
@@ -209,6 +216,15 @@ impl SimulatorTask {
         cache: SimCache,
         submit_sender: mpsc::UnboundedSender<SimResult>,
     ) {
+        // Build a dedicated runtime for CPU-heavy EVM simulation so that it
+        // cannot starve the main tokio runtime (healthcheck, channel I/O, etc.).
+        let sim_rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(self.config.concurrency_limit())
+            .thread_name("sim-worker")
+            .enable_all()
+            .build()
+            .expect("failed to create simulation runtime");
+
         loop {
             // Wait for the block environment to be set
             if self.envs.changed().await.is_err() {
@@ -227,7 +243,7 @@ impl SimulatorTask {
             let sim_cache = cache.clone();
 
             let Ok(block) = self
-                .handle_build(sim_cache, finish_by, &sim_env)
+                .handle_build(sim_cache, finish_by, &sim_env, &sim_rt)
                 .instrument(span.clone())
                 .await
                 .inspect_err(|err| span_error!(span, %err, "error during block build"))

--- a/tests/block_builder_test.rs
+++ b/tests/block_builder_test.rs
@@ -66,7 +66,8 @@ async fn test_handle_build() {
         rollup: Environment::new(block_env, ru_header),
         span: tracing::Span::none(),
     };
-    let got = block_builder.handle_build(sim_items, finish_by, &sim_env).await;
+    let sim_rt = tokio::runtime::Runtime::new().unwrap();
+    let got = block_builder.handle_build(sim_items, finish_by, &sim_env, &sim_rt).await;
 
     // Assert on the built block
     assert!(got.is_ok());


### PR DESCRIPTION
## Summary

- The simulator was running CPU-heavy EVM simulation (`BlockBuild::build()`) on the main tokio runtime, which also serves the `/healthcheck` endpoint. With `CONCURRENCY_LIMIT=10` and a 2-CPU pod, all tokio worker threads were saturated with EVM work, preventing the healthcheck from responding within the 1s liveness probe timeout — causing repeated SIGKILL (exit code 137) and a crash loop.
- This creates a dedicated `tokio::runtime::Runtime` for simulation, sized to `CONCURRENCY_LIMIT` worker threads. The main runtime stays free for healthchecks, cache I/O, and channel operations regardless of simulation load.
- No throughput loss — simulation still runs with full concurrency on its own thread pool.

## Test plan

- [ ] Verify `make clippy` and `make test` pass (confirmed locally)
- [ ] Deploy to parmigiana and confirm the pod no longer crash-loops
- [ ] Verify liveness/readiness probes pass consistently during simulation
- [ ] Confirm block building completes within the 12s slot window

🤖 Generated with [Claude Code](https://claude.com/claude-code)