### PR TITLE
feat(builder): isolate CPU heavy EVM sim work on tokio blocking task

### DIFF
--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -14,7 +14,6 @@ use signet_sim::{BlockBuild, BuiltBlock, SimCache};
 use signet_types::constants::SignetSystemConstants;
 use std::time::{Duration, Instant};
 use tokio::{
-    runtime::Runtime,
     sync::{
         mpsc::{self},
         watch,
@@ -139,7 +138,6 @@ impl SimulatorTask {
         sim_items: SimCache,
         finish_by: Instant,
         sim_env: &SimEnv,
-        sim_rt: &Runtime,
     ) -> eyre::Result<BuiltBlock> {
         let concurrency_limit = self.config.concurrency_limit();
 
@@ -156,12 +154,16 @@ impl SimulatorTask {
             self.config.max_host_gas(sim_env.prev_host().gas_limit),
         );
 
-        // Spawn the CPU-heavy EVM simulation on the dedicated runtime so it
-        // cannot starve the main tokio runtime (healthcheck, cache I/O, etc.).
-        let built_block = sim_rt
-            .spawn(block_build.build().in_current_span())
-            .await
-            .map_err(|e| eyre::eyre!("simulation task panicked: {e}"))?;
+        // Run the CPU-heavy EVM simulation on the blocking thread pool so it
+        // cannot starve the main tokio async workers (healthcheck, cache I/O,
+        // etc.). Handle::block_on re-enters the runtime context so timers and
+        // nested spawn_blocking calls inside build() continue to work.
+        let handle = tokio::runtime::Handle::current();
+        let built_block = tokio::task::spawn_blocking(move || {
+            handle.block_on(block_build.build().in_current_span())
+        })
+        .await
+        .map_err(|e| eyre::eyre!("simulation task panicked: {e}"))?;
         debug!(
             tx_count = built_block.tx_count(),
             block_number = built_block.block_number(),
@@ -216,15 +218,6 @@ impl SimulatorTask {
         cache: SimCache,
         submit_sender: mpsc::UnboundedSender<SimResult>,
     ) {
-        // Build a dedicated runtime for CPU-heavy EVM simulation so that it
-        // cannot starve the main tokio runtime (healthcheck, channel I/O, etc.).
-        let sim_rt = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(self.config.concurrency_limit())
-            .thread_name("sim-worker")
-            .enable_all()
-            .build()
-            .expect("failed to create simulation runtime");
-
         loop {
             // Wait for the block environment to be set
             if self.envs.changed().await.is_err() {
@@ -243,7 +236,7 @@ impl SimulatorTask {
             let sim_cache = cache.clone();
 
             let Ok(block) = self
-                .handle_build(sim_cache, finish_by, &sim_env, &sim_rt)
+                .handle_build(sim_cache, finish_by, &sim_env)
                 .instrument(span.clone())
                 .await
                 .inspect_err(|err| span_error!(span, %err, "error during block build"))

--- a/tests/block_builder_test.rs
+++ b/tests/block_builder_test.rs
@@ -66,8 +66,7 @@ async fn test_handle_build() {
         rollup: Environment::new(block_env, ru_header),
         span: tracing::Span::none(),
     };
-    let sim_rt = tokio::runtime::Runtime::new().unwrap();
-    let got = block_builder.handle_build(sim_items, finish_by, &sim_env, &sim_rt).await;
+    let got = block_builder.handle_build(sim_items, finish_by, &sim_env).await;
 
     // Assert on the built block
     assert!(got.is_ok());


### PR DESCRIPTION
See #233.

What we actually want is to isolate the single task, CPU heavy work from blocking the main tokio thread so that it can schedule handling healthchecks and other tasks while also continuing the sim work. Tokio can do this with spawn_blocking, which shifts the spawned task into its blocking task thread pool, avoiding the contention issue. 