### PR TITLE
perf: add benchmarks for sim_round

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9247f0a399ef71aeb68f497b2b8fb348014f742b50d3b83b1e00dfe1b7d64b3d"
+checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -488,7 +497,7 @@ dependencies = [
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -576,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -587,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -881,7 +890,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -1046,6 +1055,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -1575,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -2153,24 +2168,24 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc119a5ad34c3f459062a96907f53358989b173d104258891bb74f95d93747e8"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
  "bitflags 2.11.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "num-bigint",
  "rustc-hash",
 ]
 
 [[package]]
 name = "boa_engine"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e637ec52ea66d76b0ca86180c259d6c7bb6e6a6e14b2f36b85099306d8b00cc3"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
  "aligned-vec",
  "arrayvec",
@@ -2193,7 +2208,7 @@ dependencies = [
  "futures-lite",
  "hashbrown 0.16.1",
  "icu_normalizer",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "intrusive-collections",
  "itertools 0.14.0",
  "num-bigint",
@@ -2220,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1179f690cbfcbe5364cceee5f1cb577265bb6f07b0be6f210aabe270adcf9da"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
 dependencies = [
  "boa_macros",
  "boa_string",
@@ -2232,14 +2247,14 @@ dependencies = [
 
 [[package]]
 name = "boa_interner"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9626505d33dc63d349662437297df1d3afd9d5fc4a2b3ad34e5e1ce879a78848"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
 dependencies = [
  "boa_gc",
  "boa_macros",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -2248,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "boa_macros"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36418a46544b152632c141b0a0b7a453cd69ca150caeef83aee9e2f4b48b7d"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
 dependencies = [
  "cfg-if",
  "cow-utils",
@@ -2262,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f99bf5b684f0de946378fcfe5f38c3a0fbd51cbf83a0f39ff773a0e218541f"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
  "bitflags 2.11.0",
  "boa_ast",
@@ -2280,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ce9d7aa5563a2e14eab111e2ae1a06a69a812f6c0c3d843196c9d03fbef440"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
 dependencies = [
  "fast-float2",
  "itoa",
@@ -2365,6 +2380,7 @@ dependencies = [
  "alloy-hardforks 0.4.7",
  "axum 0.7.9",
  "backon",
+ "criterion",
  "eyre",
  "futures-util",
  "git-version",
@@ -2499,11 +2515,17 @@ checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
@@ -2516,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2565,6 +2587,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -2630,9 +2679,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -2883,6 +2932,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -3720,9 +3805,9 @@ checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -4249,11 +4334,22 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4506,9 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4521,7 +4617,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -4639,9 +4734,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4698,9 +4793,9 @@ checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4814,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "arbitrary",
  "equivalent",
@@ -4836,9 +4931,9 @@ dependencies = [
 
 [[package]]
 name = "init4-bin-base"
-version = "0.18.0-rc.13"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054d4b927194b1e73c85945a93254b19772fee2c627b190c9ae7c72da0b40eaf"
+checksum = "f94c64278d765503d752783c7a1f1052f0d41cff51cd1fd258958d94a9a03010"
 dependencies = [
  "alloy",
  "async-trait",
@@ -4952,14 +5047,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d72a21f6a71a6c4c3160e095e8925861f5119dd26ef71acee1b9146f74f76c8"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
  "socket2",
  "widestring",
+ "windows-registry",
+ "windows-result",
  "windows-sys 0.61.2",
- "winreg",
 ]
 
 [[package]]
@@ -4970,9 +5066,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -5073,10 +5169,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -5305,9 +5403,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
+checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -5347,9 +5445,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libgit2-sys"
@@ -5411,9 +5509,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -5439,9 +5537,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -5451,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5482,9 +5580,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -5662,7 +5760,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -5739,9 +5837,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -5942,9 +6040,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -6097,6 +6195,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
@@ -6253,9 +6357,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
@@ -6685,6 +6789,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6704,9 +6836,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -10264,9 +10396,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -10301,7 +10433,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -10582,9 +10714,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -10653,7 +10785,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "serde",
@@ -10674,9 +10806,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -10703,7 +10835,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -10768,9 +10900,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
+checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
 dependencies = [
  "cc",
  "cfg-if",
@@ -10889,9 +11021,9 @@ dependencies = [
 
 [[package]]
 name = "signet-bundle"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9bd62b011781950089d31f742d90b3d62ba00f374db0dfe0d3ba1f1358b45c"
+checksum = "dafb04a643cee29180ce8ae2067c81691417bc6ca6ac350146652a3f84576685"
 dependencies = [
  "alloy",
  "serde",
@@ -10905,9 +11037,9 @@ dependencies = [
 
 [[package]]
 name = "signet-constants"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9a4bb305179fc7461eb5cbee914344067ef03dccc267b20dfc1eaea9db1459"
+checksum = "f4360f5a5706c7a9d6ddea3b3d8ab7721f7341c5242bc7f3857967f28090568d"
 dependencies = [
  "alloy",
  "serde",
@@ -10941,9 +11073,9 @@ dependencies = [
 
 [[package]]
 name = "signet-evm"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55caa1277f82e8854b9daf275d20deb8a78d57fa1babdcdeed8dd2976dfca18c"
+checksum = "05cd7eb4c1a23f8b3742084283c690d04fda828f8c7aaa232b0d0a8d89861267"
 dependencies = [
  "alloy",
  "bitflags 2.11.0",
@@ -10958,9 +11090,9 @@ dependencies = [
 
 [[package]]
 name = "signet-extract"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1e5c76e9c86d5e3cc8d321e41022cf2a6658e6346119fd4c29f894d8513a1c"
+checksum = "6f23779af433acdbac5fb7a5e1489f5a1caab72f5337e2ee640c030a3bdcfb6b"
 dependencies = [
  "alloy",
  "signet-types",
@@ -10983,9 +11115,9 @@ dependencies = [
 
 [[package]]
 name = "signet-journal"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89519bce0c6d3143593cdab0501852741f66b641d048d65ec87cb095a803bd0a"
+checksum = "f4c3c665f734b1cb68ee2a0263032fd171a3737927b4793d11377b8e917f05e7"
 dependencies = [
  "alloy",
  "futures-util",
@@ -11011,9 +11143,9 @@ dependencies = [
 
 [[package]]
 name = "signet-sim"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6fe279a15c70233025257536f405c1f4c502525ef533c852f918933e0b5084"
+checksum = "8002d4b0a83bdab1568d77de5790a70a1bd2c8d58bb43649299b7b319b5f67e4"
 dependencies = [
  "alloy",
  "lru",
@@ -11030,9 +11162,9 @@ dependencies = [
 
 [[package]]
 name = "signet-tx-cache"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95529a7f5a351bf5daee91a4c25a317fcb815b0fc4a26aa7099629d619eb51b"
+checksum = "ba06dc92c72b877f042ba141c7ee553c68aab1c6e077a3ba1adb2eae17fdaff4"
 dependencies = [
  "alloy",
  "futures-util",
@@ -11049,9 +11181,9 @@ dependencies = [
 
 [[package]]
 name = "signet-types"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10dff727bb17387f043999bca9dafef6c0ba8e10e8d7c5f5fd8e53b708ea959"
+checksum = "9ad0d5db88367e5f2433e1cdd74017cf399dd985906be905032cba1ad314c30f"
 dependencies = [
  "alloy",
  "chrono",
@@ -11063,9 +11195,9 @@ dependencies = [
 
 [[package]]
 name = "signet-zenith"
-version = "0.16.0-rc.16"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c96ff57c3b9d32a452d96cbf0bd852c987688721c84877ec6218e1ceed87ed"
+checksum = "4cafc152356fad0f4461af607af6e4151a3a577b55007a60ce5587969127a6e5"
 dependencies = [
  "alloy",
  "alloy-core",
@@ -11075,9 +11207,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -11348,9 +11480,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "da322882471314edc77fa5232c587bcb87c9df52bfd0d7d4826f8868ead61899"
 
 [[package]]
 name = "thiserror"
@@ -11449,7 +11581,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -11477,13 +11608,23 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -11503,9 +11644,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -11520,9 +11661,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11610,7 +11751,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -11630,39 +11771,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "indexmap 2.13.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -11731,7 +11872,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -11991,9 +12132,9 @@ dependencies = [
 
 [[package]]
 name = "trevm"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904819c7508930edfc3c1ea7e47871aa8c6a4e0c913de5c56b7d73006845c5ae"
+checksum = "bb4a80f4985c7b8aefee9fe1ba48b6b37c617f8b5ffd88f67adbfef78d77c894"
 dependencies = [
  "alloy",
  "dashmap",
@@ -12107,9 +12248,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -12201,9 +12342,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -12330,9 +12471,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12343,23 +12484,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12367,9 +12504,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12380,9 +12517,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -12404,7 +12541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -12430,8 +12567,8 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver 1.0.27",
+ "indexmap 2.13.1",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -12450,9 +12587,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12904,21 +13041,11 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
-dependencies = [
- "cfg-if",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12949,7 +13076,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -12980,7 +13107,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -12999,9 +13126,9 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -13017,9 +13144,9 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -13079,9 +13206,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -13090,9 +13217,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13102,18 +13229,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13122,18 +13249,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13163,20 +13290,21 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -13186,9 +13314,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,14 @@ url = "2.5.4"
 [dev-dependencies]
 alloy-hardforks = "0.4.0"
 alloy-chains = "0.2"
+criterion = { version = "0.8.2", features = ["async_tokio"] }
 signet-bundle = "0.16.0-rc.11"
+
+[[bench]]
+name = "sim"
+path = "benches/sim/main.rs"
+harness = false
+required-features = ["test-utils"]
 
 # comment / uncomment for local dev
 # [patch.crates-io]

--- a/benches/sim/bundles.rs
+++ b/benches/sim/bundles.rs
@@ -1,0 +1,111 @@
+//! Benchmarks for bundle simulation: varying counts, DB latency, and concurrency.
+
+use crate::fixture::{Fixture, LATENCIES, set_up_bundle_sim, set_up_sender_distribution_sim};
+use builder::test_utils::setup_test_config;
+use criterion::{BatchSize, Bencher, BenchmarkId, Criterion};
+use std::time::Duration;
+
+pub fn bench_bundle_counts(criterion: &mut Criterion) {
+    const LATENCY: Duration = Duration::ZERO;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group = criterion.benchmark_group("sim_varying_simple_bundle_counts_no_db_latency");
+    group.sample_size(10);
+
+    for bundle_count in [1, 10, 100, 1000] {
+        group.bench_with_input(
+            BenchmarkId::new("bundle_count", bundle_count),
+            &bundle_count,
+            |bench: &mut Bencher, &bundle_count| {
+                bench.to_async(&runtime).iter_batched(
+                    || set_up_bundle_sim(bundle_count, LATENCY, CONCURRENCY),
+                    Fixture::run,
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+pub fn bench_bundle_db_latency(criterion: &mut Criterion) {
+    const BUNDLE_COUNT: usize = 10;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group =
+        criterion.benchmark_group(format!("sim_{BUNDLE_COUNT}_simple_bundles_varying_db_latency"));
+    group.sample_size(10);
+
+    for (label, latency) in LATENCIES {
+        group.bench_with_input(BenchmarkId::new("latency", label), &latency, |bench, &lat| {
+            bench.to_async(&runtime).iter_batched(
+                || set_up_bundle_sim(BUNDLE_COUNT, lat, CONCURRENCY),
+                Fixture::run,
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+pub fn bench_bundle_concurrency(criterion: &mut Criterion) {
+    const BUNDLE_COUNT: usize = 100;
+    const LATENCY: Duration = Duration::ZERO;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group = criterion.benchmark_group(format!(
+        "sim_{BUNDLE_COUNT}_simple_bundles_no_db_latency_varying_concurrency"
+    ));
+    group.sample_size(10);
+
+    for concurrency in [1, 2, 4, 8, 16] {
+        group.bench_with_input(
+            BenchmarkId::new("thread_count", concurrency),
+            &concurrency,
+            |bench, &conc| {
+                bench.to_async(&runtime).iter_batched(
+                    || set_up_bundle_sim(BUNDLE_COUNT, LATENCY, conc),
+                    Fixture::run,
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+pub fn bench_bundle_sender_distribution(criterion: &mut Criterion) {
+    const BUNDLE_COUNT: usize = 100;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group = criterion.benchmark_group(format!(
+        "sim_{BUNDLE_COUNT}_simple_bundles_no_db_latency_varying_sender_count"
+    ));
+    group.sample_size(10);
+
+    for num_senders in [1, 5, 20, 100] {
+        group.bench_with_input(
+            BenchmarkId::new("sender_count", num_senders),
+            &num_senders,
+            |bench, &senders| {
+                bench.to_async(&runtime).iter_batched(
+                    || set_up_sender_distribution_sim(BUNDLE_COUNT, senders, CONCURRENCY),
+                    Fixture::run,
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}

--- a/benches/sim/complex_bundles.rs
+++ b/benches/sim/complex_bundles.rs
@@ -1,0 +1,61 @@
+//! Benchmarks for complex bundle shapes: multi-tx bundles and bundles with host transactions.
+
+use crate::fixture::{Fixture, set_up_host_tx_bundle_sim, set_up_multi_tx_bundle_sim};
+use builder::test_utils::setup_test_config;
+use criterion::{BatchSize, BenchmarkId, Criterion};
+
+pub fn bench_multi_tx_bundles(criterion: &mut Criterion) {
+    const BUNDLE_COUNT: usize = 100;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group = criterion.benchmark_group(format!(
+        "sim_{BUNDLE_COUNT}_bundles_no_db_latency_varying_txs_per_bundle"
+    ));
+    group.sample_size(10);
+
+    for txs_per_bundle in [1, 3, 5, 10] {
+        group.bench_with_input(
+            BenchmarkId::new("txs_per_bundle", txs_per_bundle),
+            &txs_per_bundle,
+            |bench, &tpb| {
+                bench.to_async(&runtime).iter_batched(
+                    || set_up_multi_tx_bundle_sim(BUNDLE_COUNT, tpb, CONCURRENCY),
+                    Fixture::run,
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+pub fn bench_host_tx_bundles(criterion: &mut Criterion) {
+    const BUNDLE_COUNT: usize = 100;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group = criterion.benchmark_group(format!(
+        "sim_{BUNDLE_COUNT}_bundles_no_db_latency_varying_host_txs_per_bundle"
+    ));
+    group.sample_size(10);
+
+    for host_txs in [0, 1, 3, 5] {
+        group.bench_with_input(
+            BenchmarkId::new("host_txs_per_bundle", host_txs),
+            &host_txs,
+            |bench, &htpb| {
+                bench.to_async(&runtime).iter_batched(
+                    || set_up_host_tx_bundle_sim(BUNDLE_COUNT, htpb, CONCURRENCY),
+                    Fixture::run,
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}

--- a/benches/sim/failed_bundles.rs
+++ b/benches/sim/failed_bundles.rs
@@ -1,0 +1,53 @@
+//! Benchmarks for bundles that fail: preflight validation failures and EVM execution reverts.
+
+use crate::fixture::{
+    Fixture, LATENCIES, set_up_execution_failure_sim, set_up_preflight_failure_sim,
+};
+use builder::test_utils::setup_test_config;
+use criterion::{BatchSize, BenchmarkId, Criterion};
+
+pub fn bench_preflight_failure(criterion: &mut Criterion) {
+    const COUNT: usize = 10;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group =
+        criterion.benchmark_group(format!("sim_{COUNT}_simple_bundles_all_failing_preflight"));
+    group.sample_size(10);
+
+    for (label, latency) in LATENCIES {
+        group.bench_with_input(BenchmarkId::new("latency", label), &latency, |bench, &lat| {
+            bench.to_async(&runtime).iter_batched(
+                || set_up_preflight_failure_sim(COUNT, lat, CONCURRENCY),
+                Fixture::run,
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+pub fn bench_execution_failure(criterion: &mut Criterion) {
+    const COUNT: usize = 10;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group =
+        criterion.benchmark_group(format!("sim_{COUNT}_simple_bundles_all_failing_execution"));
+    group.sample_size(10);
+
+    for (label, latency) in LATENCIES {
+        group.bench_with_input(BenchmarkId::new("latency", label), &latency, |bench, &lat| {
+            bench.to_async(&runtime).iter_batched(
+                || set_up_execution_failure_sim(COUNT, lat, CONCURRENCY),
+                Fixture::run,
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}

--- a/benches/sim/fixture.rs
+++ b/benches/sim/fixture.rs
@@ -1,0 +1,429 @@
+//! Shared fixtures and setup functions for simulation benchmarks.
+
+use alloy::{
+    primitives::{Address, Bytes, U256},
+    serde::OtherFields,
+    signers::local::PrivateKeySigner,
+};
+use builder::test_utils::{
+    DEFAULT_BALANCE, DEFAULT_BASEFEE, TestDb, TestDbBuilder, TestHostEnv, TestRollupEnv,
+    TestSimEnvBuilder, TestStateSource, create_call_tx, create_transfer_tx,
+    scenarios_test_block_env,
+};
+use signet_bundle::RecoveredBundle;
+use signet_sim::{SharedSimEnv, SimCache};
+use std::time::Duration;
+use tokio::time::Instant;
+use trevm::revm::bytecode::Bytecode;
+use trevm::revm::inspector::NoOpInspector;
+
+pub const BLOCK_NUMBER: u64 = 100;
+pub const BLOCK_TIMESTAMP: u64 = 1_700_000_000;
+pub const RU_CHAIN_ID: u64 = 88888;
+pub const DEFAULT_PRIORITY_FEE: u128 = 10_000_000_000;
+pub const MAX_GAS: u64 = 3_000_000_000;
+pub const MAX_HOST_GAS: u64 = 24_000_000;
+pub const REVERTING_CONTRACT: Address = Address::repeat_byte(0xBB);
+/// Latency values based on real-world RPC provider benchmarks:
+/// - 0ms:   baseline, no network simulation
+/// - 50ms:  good provider, same-region (p50 for top providers)
+/// - 200ms: cross-region or average provider
+pub const LATENCIES: [(&str, Duration); 3] = [
+    ("0ms", Duration::ZERO),
+    ("50ms", Duration::from_millis(50)),
+    ("200ms", Duration::from_millis(200)),
+];
+
+/// Type alias for the shared simulation environment used in benchmarks.
+pub type BenchSimEnv = SharedSimEnv<TestDb, TestDb, NoOpInspector, NoOpInspector>;
+
+/// Everything needed to run a benchmark iteration: the simulation environment
+/// plus state sources for preflight validity checks.
+pub struct Fixture {
+    env: BenchSimEnv,
+    rollup_source: TestStateSource,
+    host_source: TestStateSource,
+}
+
+impl Fixture {
+    fn new(envs: Envs, concurrency: usize, cache: SimCache) -> Self {
+        let Envs { rollup_env, host_env, rollup_source, host_source } = envs;
+        // Set a deadline far in the future so that `sim_round()` never short-circuits.
+        let finish_by = Instant::now() + Duration::from_secs(3600);
+        let env = SharedSimEnv::new(rollup_env, host_env, finish_by, concurrency, cache);
+        Fixture { env, rollup_source, host_source }
+    }
+
+    /// Drain all items from the sim env via repeated `sim_round()` calls.
+    pub async fn run(self) {
+        let Fixture { mut env, rollup_source, host_source } = self;
+        while env.sim_round(MAX_GAS, MAX_HOST_GAS, &rollup_source, &host_source).await.is_some() {}
+    }
+}
+
+struct Envs {
+    rollup_env: TestRollupEnv,
+    host_env: TestHostEnv,
+    rollup_source: TestStateSource,
+    host_source: TestStateSource,
+}
+
+impl Envs {
+    /// Build simulation environments and state sources from a shared database.
+    fn new(db: TestDb) -> Self {
+        let block_env =
+            scenarios_test_block_env(BLOCK_NUMBER, DEFAULT_BASEFEE, BLOCK_TIMESTAMP, MAX_GAS);
+
+        let sim_env = TestSimEnvBuilder::new()
+            .with_rollup_db(db.clone())
+            .with_host_db(db.clone())
+            .with_block_env(block_env);
+
+        let rollup_source = TestStateSource::new(db.clone());
+        let host_source = TestStateSource::new(db);
+        let (rollup_env, host_env) = sim_env.build();
+        Envs { rollup_env, host_env, rollup_source, host_source }
+    }
+}
+
+/// Generate `count` random funded signers.
+fn generate_signers(count: usize) -> Vec<PrivateKeySigner> {
+    (0..count).map(|_| PrivateKeySigner::random()).collect()
+}
+
+/// Create a `TestDbBuilder` with accounts funded from the given signers.
+fn fund_accounts(signers: &[PrivateKeySigner]) -> TestDbBuilder {
+    let balance = U256::from(DEFAULT_BALANCE);
+    let mut builder = TestDbBuilder::new();
+    for signer in signers {
+        builder = builder.with_account(signer.address(), balance, 0);
+    }
+    builder
+}
+
+/// Create a `RecoveredBundle` with one transfer transaction.
+fn make_bundle(
+    signer: &PrivateKeySigner,
+    to: Address,
+    nonce: u64,
+    uuid: String,
+    max_priority_fee: u128,
+) -> RecoveredBundle {
+    let tx =
+        create_transfer_tx(signer, to, U256::from(1_000u64), nonce, RU_CHAIN_ID, max_priority_fee)
+            .unwrap();
+
+    RecoveredBundle::new_unchecked(
+        vec![tx],
+        vec![],
+        BLOCK_NUMBER,
+        Some(BLOCK_TIMESTAMP - 100),
+        Some(BLOCK_TIMESTAMP + 100),
+        vec![],
+        Some(uuid),
+        vec![],
+        None,
+        None,
+        vec![],
+        OtherFields::default(),
+    )
+}
+
+/// Build a [`SharedSimEnv`] and state sources with bundles in the cache.
+///
+/// All databases use the same latency to model production RPC round-trips
+/// (both simulation environments and preflight state sources hit the RPC).
+pub fn set_up_bundle_sim(count: usize, latency: Duration, concurrency: usize) -> Fixture {
+    let signers = generate_signers(count);
+    let db = fund_accounts(&signers).with_latency(latency).build();
+    let envs = Envs::new(db);
+
+    let cache = SimCache::with_capacity(count);
+    let recipient = Address::repeat_byte(0xAA);
+    let bundles: Vec<RecoveredBundle> = signers
+        .iter()
+        .enumerate()
+        .map(|(idx, signer)| {
+            make_bundle(signer, recipient, 0, format!("bench-{idx}"), DEFAULT_PRIORITY_FEE)
+        })
+        .collect();
+    cache.add_bundles(bundles, DEFAULT_BASEFEE);
+
+    Fixture::new(envs, concurrency, cache)
+}
+
+/// Build a [`SharedSimEnv`] and state sources with standalone txs in the cache.
+pub fn set_up_tx_sim(count: usize, latency: Duration, concurrency: usize) -> Fixture {
+    let signers = generate_signers(count);
+    let db = fund_accounts(&signers).with_latency(latency).build();
+    let envs = Envs::new(db);
+
+    let cache = SimCache::with_capacity(count);
+    let recipient = Address::repeat_byte(0xAA);
+    for signer in &signers {
+        let tx = create_transfer_tx(
+            signer,
+            recipient,
+            U256::from(1_000u64),
+            0,
+            RU_CHAIN_ID,
+            DEFAULT_PRIORITY_FEE,
+        )
+        .unwrap();
+        cache.add_tx(tx, DEFAULT_BASEFEE);
+    }
+
+    Fixture::new(envs, concurrency, cache)
+}
+
+/// Build a [`SharedSimEnv`] with bundles that all fail preflight validation.
+///
+/// Accounts are funded with nonce 1, but all bundles use nonce 0. Since
+/// `state_nonce > tx_nonce`, every item is marked `Never` and removed from the
+/// cache on the first `sim_round()` call.
+pub fn set_up_preflight_failure_sim(
+    count: usize,
+    latency: Duration,
+    concurrency: usize,
+) -> Fixture {
+    let signers = generate_signers(count);
+
+    let balance = U256::from(DEFAULT_BALANCE);
+    let mut db_builder = TestDbBuilder::new();
+    for signer in &signers {
+        db_builder = db_builder.with_account(signer.address(), balance, 1);
+    }
+    let db = db_builder.with_latency(latency).build();
+    let envs = Envs::new(db);
+
+    let cache = SimCache::with_capacity(count);
+    let recipient = Address::repeat_byte(0xAA);
+    let bundles: Vec<RecoveredBundle> = signers
+        .iter()
+        .enumerate()
+        .map(|(idx, signer)| {
+            make_bundle(signer, recipient, 0, format!("bench-{idx}"), DEFAULT_PRIORITY_FEE)
+        })
+        .collect();
+    cache.add_bundles(bundles, DEFAULT_BASEFEE);
+
+    Fixture::new(envs, concurrency, cache)
+}
+
+/// Build a [`SharedSimEnv`] with bundles that pass preflight but revert during
+/// EVM execution.
+///
+/// A contract at [`REVERTING_CONTRACT`] contains `PUSH0 PUSH0 REVERT` (always
+/// reverts with empty data). All bundles call this contract, so they pass
+/// preflight (valid nonce + sufficient balance) but fail during simulation.
+pub fn set_up_execution_failure_sim(
+    count: usize,
+    latency: Duration,
+    concurrency: usize,
+) -> Fixture {
+    let signers = generate_signers(count);
+
+    // PUSH0 PUSH0 REVERT — always reverts with empty returndata.
+    let revert_bytecode = Bytecode::new_raw(Bytes::from_static(&[0x5F, 0x5F, 0xFD]));
+
+    let balance = U256::from(DEFAULT_BALANCE);
+    let mut db_builder = TestDbBuilder::new().with_contract(REVERTING_CONTRACT, revert_bytecode);
+    for signer in &signers {
+        db_builder = db_builder.with_account(signer.address(), balance, 0);
+    }
+    let db = db_builder.with_latency(latency).build();
+    let envs = Envs::new(db);
+
+    let cache = SimCache::with_capacity(count);
+    let bundles: Vec<RecoveredBundle> = signers
+        .iter()
+        .enumerate()
+        .map(|(idx, signer)| {
+            let tx = create_call_tx(
+                signer,
+                REVERTING_CONTRACT,
+                Bytes::new(),
+                U256::ZERO,
+                0,
+                RU_CHAIN_ID,
+                50_000,
+                DEFAULT_PRIORITY_FEE,
+            )
+            .unwrap();
+            RecoveredBundle::new_unchecked(
+                vec![tx],
+                vec![],
+                BLOCK_NUMBER,
+                Some(BLOCK_TIMESTAMP - 100),
+                Some(BLOCK_TIMESTAMP + 100),
+                vec![],
+                Some(format!("bench-{idx}")),
+                vec![],
+                None,
+                None,
+                vec![],
+                OtherFields::default(),
+            )
+        })
+        .collect();
+    cache.add_bundles(bundles, DEFAULT_BASEFEE);
+
+    Fixture::new(envs, concurrency, cache)
+}
+
+/// Build a [`SharedSimEnv`] with `bundle_count` bundles spread across `num_senders` signers.
+///
+/// Each signer sends `bundle_count / num_senders` bundles with incrementing nonces.
+pub fn set_up_sender_distribution_sim(
+    bundle_count: usize,
+    num_senders: usize,
+    concurrency: usize,
+) -> Fixture {
+    let signers = generate_signers(num_senders);
+    let bundles_per_sender = bundle_count / num_senders;
+
+    let balance = U256::from(DEFAULT_BALANCE);
+    let mut db_builder = TestDbBuilder::new();
+    for signer in &signers {
+        db_builder = db_builder.with_account(signer.address(), balance, 0);
+    }
+    let db = db_builder.build();
+    let envs = Envs::new(db);
+
+    let cache = SimCache::with_capacity(bundle_count);
+    let recipient = Address::repeat_byte(0xAA);
+    let bundles: Vec<RecoveredBundle> = signers
+        .iter()
+        .enumerate()
+        .flat_map(|(sender_idx, signer)| {
+            (0..bundles_per_sender).map(move |nonce| {
+                make_bundle(
+                    signer,
+                    recipient,
+                    nonce as u64,
+                    format!("bench-{sender_idx}-{nonce}"),
+                    DEFAULT_PRIORITY_FEE,
+                )
+            })
+        })
+        .collect();
+    cache.add_bundles(bundles, DEFAULT_BASEFEE);
+
+    Fixture::new(envs, concurrency, cache)
+}
+
+/// Build a [`SharedSimEnv`] with bundles containing multiple rollup transactions each.
+///
+/// Each bundle has `txs_per_bundle` transfer transactions from the same sender with
+/// incrementing nonces. This measures the cost of simulating larger bundles where
+/// all transactions must succeed atomically.
+pub fn set_up_multi_tx_bundle_sim(
+    bundle_count: usize,
+    txs_per_bundle: usize,
+    concurrency: usize,
+) -> Fixture {
+    let signers = generate_signers(bundle_count);
+    let db = fund_accounts(&signers).build();
+    let envs = Envs::new(db);
+
+    let cache = SimCache::with_capacity(bundle_count);
+    let recipient = Address::repeat_byte(0xAA);
+    let bundles: Vec<RecoveredBundle> = signers
+        .iter()
+        .enumerate()
+        .map(|(idx, signer)| {
+            let txs: Vec<_> = (0..txs_per_bundle)
+                .map(|nonce| {
+                    create_transfer_tx(
+                        signer,
+                        recipient,
+                        U256::from(1_000u64),
+                        nonce as u64,
+                        RU_CHAIN_ID,
+                        DEFAULT_PRIORITY_FEE,
+                    )
+                    .unwrap()
+                })
+                .collect();
+            RecoveredBundle::new_unchecked(
+                txs,
+                vec![],
+                BLOCK_NUMBER,
+                Some(BLOCK_TIMESTAMP - 100),
+                Some(BLOCK_TIMESTAMP + 100),
+                vec![],
+                Some(format!("bench-{idx}")),
+                vec![],
+                None,
+                None,
+                vec![],
+                OtherFields::default(),
+            )
+        })
+        .collect();
+    cache.add_bundles(bundles, DEFAULT_BASEFEE);
+
+    Fixture::new(envs, concurrency, cache)
+}
+
+/// Build a [`SharedSimEnv`] with bundles that include host-chain transactions.
+///
+/// Each bundle has one rollup transfer plus `host_txs_per_bundle` host-chain transfers.
+/// This measures the overhead of bundles that carry cross-chain transactions.
+pub fn set_up_host_tx_bundle_sim(
+    bundle_count: usize,
+    host_txs_per_bundle: usize,
+    concurrency: usize,
+) -> Fixture {
+    let signers = generate_signers(bundle_count);
+    let db = fund_accounts(&signers).build();
+    let envs = Envs::new(db);
+
+    let cache = SimCache::with_capacity(bundle_count);
+    let recipient = Address::repeat_byte(0xAA);
+    let bundles: Vec<RecoveredBundle> = signers
+        .iter()
+        .enumerate()
+        .map(|(idx, signer)| {
+            let rollup_tx = create_transfer_tx(
+                signer,
+                recipient,
+                U256::from(1_000u64),
+                0,
+                RU_CHAIN_ID,
+                DEFAULT_PRIORITY_FEE,
+            )
+            .unwrap();
+            let host_txs: Vec<_> = (0..host_txs_per_bundle)
+                .map(|nonce| {
+                    create_transfer_tx(
+                        signer,
+                        recipient,
+                        U256::from(1_000u64),
+                        (nonce + 1) as u64,
+                        RU_CHAIN_ID,
+                        DEFAULT_PRIORITY_FEE,
+                    )
+                    .unwrap()
+                })
+                .collect();
+            RecoveredBundle::new_unchecked(
+                vec![rollup_tx],
+                host_txs,
+                BLOCK_NUMBER,
+                Some(BLOCK_TIMESTAMP - 100),
+                Some(BLOCK_TIMESTAMP + 100),
+                vec![],
+                Some(format!("bench-{idx}")),
+                vec![],
+                None,
+                None,
+                vec![],
+                OtherFields::default(),
+            )
+        })
+        .collect();
+    cache.add_bundles(bundles, DEFAULT_BASEFEE);
+
+    Fixture::new(envs, concurrency, cache)
+}

--- a/benches/sim/main.rs
+++ b/benches/sim/main.rs
@@ -1,0 +1,22 @@
+mod bundles;
+mod complex_bundles;
+mod failed_bundles;
+mod fixture;
+mod txs;
+
+use criterion::{criterion_group, criterion_main};
+
+criterion_group!(
+    benches,
+    bundles::bench_bundle_counts,
+    bundles::bench_bundle_db_latency,
+    bundles::bench_bundle_concurrency,
+    bundles::bench_bundle_sender_distribution,
+    complex_bundles::bench_multi_tx_bundles,
+    complex_bundles::bench_host_tx_bundles,
+    txs::bench_tx_counts,
+    txs::bench_tx_db_latency,
+    failed_bundles::bench_preflight_failure,
+    failed_bundles::bench_execution_failure,
+);
+criterion_main!(benches);

--- a/benches/sim/txs.rs
+++ b/benches/sim/txs.rs
@@ -1,0 +1,55 @@
+//! Benchmarks for standalone transaction simulation: varying counts and DB latency.
+
+use crate::fixture::{Fixture, LATENCIES, set_up_tx_sim};
+use builder::test_utils::setup_test_config;
+use criterion::{BatchSize, Bencher, BenchmarkId, Criterion};
+use std::time::Duration;
+
+pub fn bench_tx_counts(criterion: &mut Criterion) {
+    const LATENCY: Duration = Duration::ZERO;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group = criterion.benchmark_group("sim_varying_tx_counts_with_no_db_latency");
+    group.sample_size(10);
+
+    for tx_count in [1, 10, 100, 1000] {
+        group.bench_with_input(
+            BenchmarkId::new("tx_count", tx_count),
+            &tx_count,
+            |bench: &mut Bencher, &tx_count| {
+                bench.to_async(&runtime).iter_batched(
+                    || set_up_tx_sim(tx_count, LATENCY, CONCURRENCY),
+                    Fixture::run,
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+pub fn bench_tx_db_latency(criterion: &mut Criterion) {
+    const TX_COUNT: usize = 10;
+    const CONCURRENCY: usize = 4;
+
+    setup_test_config();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group =
+        criterion.benchmark_group(format!("sim_{TX_COUNT}_txs_with_varying_db_latency"));
+    group.sample_size(10);
+
+    for (label, latency) in LATENCIES {
+        group.bench_with_input(BenchmarkId::new("latency", label), &latency, |bench, &lat| {
+            bench.to_async(&runtime).iter_batched(
+                || set_up_tx_sim(TX_COUNT, lat, CONCURRENCY),
+                Fixture::run,
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}

--- a/src/test_utils/db.rs
+++ b/src/test_utils/db.rs
@@ -4,17 +4,20 @@
 
 use alloy::primitives::{Address, B256, U256};
 use signet_sim::{AcctInfo, StateSource};
+use std::time::Duration;
 use trevm::revm::{
+    bytecode::Bytecode,
     database::{CacheDB, EmptyDB},
     database_interface::DatabaseRef,
+    primitives::{StorageKey, StorageValue},
     state::AccountInfo,
 };
 
-/// In-memory database for testing (no network access required).
-/// This is a type alias for revm's `CacheDB<EmptyDB>`, which stores all
-/// blockchain state in memory. It implements `DatabaseRef` and can be used
-/// with `RollupEnv` and `HostEnv` for offline simulation testing.
-pub type TestDb = CacheDB<EmptyDB>;
+/// Mirrors the production `CacheDB<AlloyDB>` stack: the outer [`CacheDB`] starts
+/// empty and caches on the mutable `Database` path, while the inner [`LatencyDb`]
+/// holds all state in-memory and applies configurable sleep on every read to
+/// simulate RPC round-trip cost.
+pub type TestDb = CacheDB<LatencyDb>;
 
 /// A [`StateSource`] for testing backed by an in-memory [`TestDb`].
 /// Returns actual account info (nonce, balance) from the database,
@@ -52,7 +55,7 @@ impl StateSource for TestStateSource {
 /// before running simulations.
 #[derive(Debug)]
 pub struct TestDbBuilder {
-    db: TestDb,
+    latency_db: LatencyDb,
 }
 
 impl Default for TestDbBuilder {
@@ -64,7 +67,7 @@ impl Default for TestDbBuilder {
 impl TestDbBuilder {
     /// Create a new empty test database builder.
     pub fn new() -> Self {
-        Self { db: CacheDB::new(EmptyDB::default()) }
+        Self { latency_db: LatencyDb::default() }
     }
 
     /// Add an account with the specified balance and nonce.
@@ -75,7 +78,9 @@ impl TestDbBuilder {
     /// * `balance` - The account balance in wei
     /// * `nonce` - The account nonce (transaction count)
     pub fn with_account(mut self, address: Address, balance: U256, nonce: u64) -> Self {
-        self.db.insert_account_info(address, AccountInfo { balance, nonce, ..Default::default() });
+        self.latency_db
+            .in_mem_db
+            .insert_account_info(address, AccountInfo { balance, nonce, ..Default::default() });
         self
     }
 
@@ -88,10 +93,10 @@ impl TestDbBuilder {
     /// * `value` - The value to store
     pub fn with_storage(mut self, address: Address, slot: U256, value: U256) -> Self {
         // Ensure the account exists before setting storage
-        if !self.db.cache.accounts.contains_key(&address) {
-            self.db.insert_account_info(address, AccountInfo::default());
+        if !self.latency_db.in_mem_db.cache.accounts.contains_key(&address) {
+            self.latency_db.in_mem_db.insert_account_info(address, AccountInfo::default());
         }
-        let _ = self.db.insert_account_storage(address, slot, value);
+        let _ = self.latency_db.in_mem_db.insert_account_storage(address, slot, value);
         self
     }
 
@@ -104,60 +109,78 @@ impl TestDbBuilder {
     /// * `number` - The block number
     /// * `hash` - The block hash
     pub fn with_block_hash(mut self, number: u64, hash: B256) -> Self {
-        self.db.cache.block_hashes.insert(U256::from(number), hash);
+        self.latency_db.in_mem_db.cache.block_hashes.insert(U256::from(number), hash);
+        self
+    }
+
+    /// Add a contract account with the specified bytecode.
+    pub fn with_contract(mut self, address: Address, bytecode: Bytecode) -> Self {
+        self.latency_db.in_mem_db.insert_account_info(
+            address,
+            AccountInfo { code: Some(bytecode), ..Default::default() },
+        );
+        self
+    }
+
+    /// Apply the given latency to every call to the wrapped, in-memory DB.
+    pub const fn with_latency(mut self, latency: Duration) -> Self {
+        self.latency_db.latency = Some(latency);
         self
     }
 
     /// Build the test database.
     pub fn build(self) -> TestDb {
-        self.db
+        CacheDB::new(self.latency_db)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// In-memory database with configurable per-access latency.
+///
+/// Holds all state (accounts, storage, block hashes) in plain hash maps and
+/// calls [`std::thread::sleep`] before every read through [`DatabaseRef`].
+/// This simulates production conditions where the backing store (e.g. `AlloyDB`)
+/// sends an RPC for each state lookup.
+///
+/// Intended to be wrapped in a [`CacheDB`] so that the `CacheDB` provides real
+/// mutable-path caching while this type represents the slow backing store behind it.
+#[derive(Debug, Clone, Default)]
+pub struct LatencyDb {
+    in_mem_db: CacheDB<EmptyDB>,
+    latency: Option<Duration>,
+}
 
-    #[test]
-    fn test_db_builder_creates_empty_db() {
-        let db = TestDbBuilder::new().build();
-        assert!(db.cache.accounts.is_empty());
+impl LatencyDb {
+    fn sleep(&self) {
+        if let Some(latency) = self.latency {
+            std::thread::sleep(latency);
+        }
+    }
+}
+
+impl DatabaseRef for LatencyDb {
+    type Error = core::convert::Infallible;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.sleep();
+        Ok(self.in_mem_db.basic_ref(address).unwrap())
     }
 
-    #[test]
-    fn test_db_builder_adds_account() {
-        let address = Address::repeat_byte(0x01);
-        let balance = U256::from(1000u64);
-        let nonce = 5u64;
-
-        let db = TestDbBuilder::new().with_account(address, balance, nonce).build();
-
-        let account = db.cache.accounts.get(&address).unwrap();
-        assert_eq!(account.info.balance, balance);
-        assert_eq!(account.info.nonce, nonce);
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.sleep();
+        Ok(self.in_mem_db.code_by_hash_ref(code_hash).unwrap())
     }
 
-    #[test]
-    fn test_db_builder_adds_storage() {
-        let address = Address::repeat_byte(0x01);
-        let slot = U256::from(42u64);
-        let value = U256::from(123u64);
-
-        let db = TestDbBuilder::new().with_storage(address, slot, value).build();
-
-        let account = db.cache.accounts.get(&address).unwrap();
-        let stored = account.storage.get(&slot).unwrap();
-        assert_eq!(*stored, value);
+    fn storage_ref(
+        &self,
+        address: Address,
+        index: StorageKey,
+    ) -> Result<StorageValue, Self::Error> {
+        self.sleep();
+        Ok(self.in_mem_db.storage_ref(address, index).unwrap())
     }
 
-    #[test]
-    fn test_db_builder_adds_block_hash() {
-        let number = 100u64;
-        let hash = B256::repeat_byte(0xab);
-
-        let db = TestDbBuilder::new().with_block_hash(number, hash).build();
-
-        let stored = db.cache.block_hashes.get(&U256::from(number)).unwrap();
-        assert_eq!(*stored, hash);
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        self.sleep();
+        Ok(self.in_mem_db.block_hash_ref(number).unwrap())
     }
 }

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -12,7 +12,7 @@ mod tx;
 
 // Re-export test harness components
 pub use block::{TestBlockBuild, TestBlockBuildBuilder, quick_build_block};
-pub use db::{TestDb, TestDbBuilder, TestStateSource};
+pub use db::{LatencyDb, TestDb, TestDbBuilder, TestStateSource};
 pub use env::{TestHostEnv, TestRollupEnv, TestSimEnvBuilder};
 pub use scenarios::{
     DEFAULT_BALANCE, DEFAULT_BASEFEE, basic_scenario, custom_funded_scenario, funded_test_db,


### PR DESCRIPTION
## Description

- Adds Criterion benchmarks for `sim_round()` covering bundles (varying count, DB latency, concurrency, sender distribution), standalone transactions, complex bundle shapes (multi-tx, host txs), and failure paths (preflight and EVM revert).
- Introduces `LatencyDb` wrapper around the in-memory test DB that sleeps on every `DatabaseRef` read, simulating real RPC round-trip costs. `TestDb` is now `CacheDB<LatencyDb>`, mirroring the production `CacheDB<AlloyDB>` layering, with existing tests using the `LatencyDb` with latency disabled to match existing behaviour.
- Extends `TestDbBuilder` with `with_contract()` and `with_latency()` helpers.

<details>
<summary>Example benchmark output</summary>

The command:
```bash
cargo bench --bench sim
```

This was run on a Ryzen 9 7900X × 24, and ran for ~11m 15s:

```
sim_varying_simple_bundle_counts_no_db_latency/bundle_count/1
                        time:   [234.55 µs 235.87 µs 236.86 µs]
sim_varying_simple_bundle_counts_no_db_latency/bundle_count/10
                        time:   [3.2674 ms 3.2835 ms 3.3035 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
sim_varying_simple_bundle_counts_no_db_latency/bundle_count/100
                        time:   [33.786 ms 33.863 ms 33.987 ms]
sim_varying_simple_bundle_counts_no_db_latency/bundle_count/1000
                        time:   [343.52 ms 345.19 ms 346.62 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild

sim_10_simple_bundles_varying_db_latency/latency/0ms
                        time:   [3.2407 ms 3.2535 ms 3.2647 ms]
Benchmarking sim_10_simple_bundles_varying_db_latency/latency/50ms: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 23.6s.
sim_10_simple_bundles_varying_db_latency/latency/50ms
                        time:   [2.3594 s 2.3597 s 2.3600 s]
Benchmarking sim_10_simple_bundles_varying_db_latency/latency/200ms: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 94.1s.
sim_10_simple_bundles_varying_db_latency/latency/200ms
                        time:   [9.4096 s 9.4099 s 9.4102 s]

sim_100_simple_bundles_no_db_latency_varying_concurrency/thread_count/1
                        time:   [25.504 ms 25.540 ms 25.563 ms]
sim_100_simple_bundles_no_db_latency_varying_concurrency/thread_count/2
                        time:   [28.179 ms 28.720 ms 29.240 ms]
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
sim_100_simple_bundles_no_db_latency_varying_concurrency/thread_count/4
                        time:   [33.793 ms 33.951 ms 34.096 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
sim_100_simple_bundles_no_db_latency_varying_concurrency/thread_count/8
                        time:   [45.229 ms 45.770 ms 46.057 ms]
sim_100_simple_bundles_no_db_latency_varying_concurrency/thread_count/16
                        time:   [77.430 ms 77.688 ms 78.221 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

sim_100_simple_bundles_no_db_latency_varying_sender_count/sender_count/1
                        time:   [25.908 ms 26.031 ms 26.129 ms]
sim_100_simple_bundles_no_db_latency_varying_sender_count/sender_count/5
                        time:   [31.306 ms 31.576 ms 31.929 ms]
sim_100_simple_bundles_no_db_latency_varying_sender_count/sender_count/20
                        time:   [33.422 ms 33.503 ms 33.601 ms]
sim_100_simple_bundles_no_db_latency_varying_sender_count/sender_count/100
                        time:   [34.148 ms 34.665 ms 35.716 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

sim_100_bundles_no_db_latency_varying_txs_per_bundle/txs_per_bundle/1
                        time:   [33.863 ms 34.031 ms 34.157 ms]
sim_100_bundles_no_db_latency_varying_txs_per_bundle/txs_per_bundle/3
                        time:   [63.696 ms 63.886 ms 64.097 ms]
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking sim_100_bundles_no_db_latency_varying_txs_per_bundle/txs_per_bundle/5: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.0s or enable flat sampling.
sim_100_bundles_no_db_latency_varying_txs_per_bundle/txs_per_bundle/5
                        time:   [92.419 ms 93.891 ms 95.434 ms]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
sim_100_bundles_no_db_latency_varying_txs_per_bundle/txs_per_bundle/10
                        time:   [166.92 ms 168.18 ms 169.37 ms]

sim_100_bundles_no_db_latency_varying_host_txs_per_bundle/host_txs_per_bundle/0
                        time:   [33.835 ms 33.965 ms 34.063 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
sim_100_bundles_no_db_latency_varying_host_txs_per_bundle/host_txs_per_bundle/1
                        time:   [21.841 µs 23.201 µs 25.496 µs]
sim_100_bundles_no_db_latency_varying_host_txs_per_bundle/host_txs_per_bundle/3
                        time:   [22.594 µs 24.331 µs 25.891 µs]
sim_100_bundles_no_db_latency_varying_host_txs_per_bundle/host_txs_per_bundle/5
                        time:   [25.124 µs 27.394 µs 29.828 µs]

sim_varying_tx_counts_with_no_db_latency/tx_count/1
                        time:   [265.82 µs 266.57 µs 267.39 µs]
sim_varying_tx_counts_with_no_db_latency/tx_count/10
                        time:   [3.5487 ms 3.5803 ms 3.6148 ms]
sim_varying_tx_counts_with_no_db_latency/tx_count/100
                        time:   [36.645 ms 36.836 ms 37.062 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
sim_varying_tx_counts_with_no_db_latency/tx_count/1000
                        time:   [385.71 ms 388.59 ms 390.86 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild

sim_10_txs_with_varying_db_latency/latency/0ms
                        time:   [13.908 ms 15.909 ms 17.080 ms]
Benchmarking sim_10_txs_with_varying_db_latency/latency/50ms: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 23.9s.
sim_10_txs_with_varying_db_latency/latency/50ms
                        time:   [2.3710 s 2.3771 s 2.3831 s]
Found 3 outliers among 10 measurements (30.00%)
  2 (20.00%) low mild
  1 (10.00%) high mild
Benchmarking sim_10_txs_with_varying_db_latency/latency/200ms: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 94.4s.
sim_10_txs_with_varying_db_latency/latency/200ms
                        time:   [9.4087 s 9.4115 s 9.4164 s]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

sim_10_simple_bundles_all_failing_preflight/latency/0ms
                        time:   [2.2787 µs 2.3106 µs 2.3489 µs]
Benchmarking sim_10_simple_bundles_all_failing_preflight/latency/50ms: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.0s.
sim_10_simple_bundles_all_failing_preflight/latency/50ms
                        time:   [500.62 ms 500.66 ms 500.73 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking sim_10_simple_bundles_all_failing_preflight/latency/200ms: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 20.0s.
sim_10_simple_bundles_all_failing_preflight/latency/200ms
                        time:   [2.0006 s 2.0007 s 2.0007 s]

sim_10_simple_bundles_all_failing_execution/latency/0ms
                        time:   [343.26 µs 346.63 µs 350.19 µs]
sim_10_simple_bundles_all_failing_execution/latency/50ms
                        time:   [401.17 ms 401.22 ms 401.27 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking sim_10_simple_bundles_all_failing_execution/latency/200ms: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 16.0s.
sim_10_simple_bundles_all_failing_execution/latency/200ms
                        time:   [1.6012 s 1.6013 s 1.6015 s]
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
```

</details>

## Related Issue

Closes ENG-1956.

## Testing

- [x] `make fmt` passes
- [x] `make clippy` passes
- [x] `make test` passes
- [x] New tests added (if applicable)
