### PR TITLE
chore: centralize metrics functions

### DIFF
--- a/bin/builder.rs
+++ b/bin/builder.rs
@@ -58,6 +58,7 @@ async fn main() -> eyre::Result<()> {
     }
 
     let config = builder::config_from_env();
+    builder::init_metrics();
     let init_span_guard = info_span!("builder initialization").entered();
 
     info!(pkg_version = PKG_VERSION, git_commit = GIT_COMMIT, "starting builder");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@
 #[macro_use]
 mod macros;
 
+/// Centralized metrics for the builder.
+pub(crate) mod metrics;
+
 /// Configuration for the Builder binary.
 pub mod config;
 
@@ -70,6 +73,12 @@ pub fn config_from_env() -> &'static config::BuilderConfig {
 /// Panics if the configuration has not been initialized.
 pub fn config() -> &'static config::BuilderConfig {
     &CONFIG_AND_GUARD.get().expect("Builder config not initialized").config
+}
+
+/// Register all metric descriptions. Call once at startup after the metrics
+/// recorder is installed.
+pub fn init_metrics() {
+    metrics::init();
 }
 
 /// Get a reference to the Signet system constants from the global Builder

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,405 @@
+//! Centralized metrics for the builder.
+//!
+//! All metrics are defined and described here so that callers never need to
+//! use bare `counter!` / `histogram!` macros directly. This prevents
+//! metric-name typos and provides a single place to survey every metric the
+//! builder emits.
+use init4_bin_base::deps::metrics::{counter, describe_counter, describe_histogram, histogram};
+use std::sync::LazyLock;
+
+// ---------------------------------------------------------------------------
+// Metric names and help text
+// ---------------------------------------------------------------------------
+
+// -- Block building --
+
+const BUILT_BLOCKS: &str = "signet.builder.built_blocks";
+const BUILT_BLOCKS_HELP: &str = "Number of blocks built by the simulator.";
+
+const BUILT_BLOCKS_TX_COUNT: &str = "signet.builder.built_blocks.tx_count";
+const BUILT_BLOCKS_TX_COUNT_HELP: &str = "Transaction count per built block.";
+
+// -- Cache polling --
+
+const TX_NONCE_STALE: &str = "signet.builder.cache.tx_nonce_stale";
+const TX_NONCE_STALE_HELP: &str = "Transactions dropped due to stale nonce.";
+
+const TX_POLL_COUNT: &str = "signet.builder.cache.tx_poll_count";
+const TX_POLL_COUNT_HELP: &str = "Transaction cache poll attempts.";
+
+const TX_POLL_ERRORS: &str = "signet.builder.cache.tx_poll_errors";
+const TX_POLL_ERRORS_HELP: &str = "Transaction cache poll errors.";
+
+const TXS_FETCHED: &str = "signet.builder.cache.txs_fetched";
+const TXS_FETCHED_HELP: &str = "Transactions fetched per poll cycle.";
+
+const BUNDLE_POLL_COUNT: &str = "signet.builder.cache.bundle_poll_count";
+const BUNDLE_POLL_COUNT_HELP: &str = "Bundle cache poll attempts.";
+
+const BUNDLE_POLL_ERRORS: &str = "signet.builder.cache.bundle_poll_errors";
+const BUNDLE_POLL_ERRORS_HELP: &str = "Bundle cache poll errors.";
+
+const BUNDLES_FETCHED: &str = "signet.builder.cache.bundles_fetched";
+const BUNDLES_FETCHED_HELP: &str = "Bundles fetched per poll cycle.";
+
+// -- Cache ingestion --
+
+const CACHE_CLEANS: &str = "signet.builder.cache.cache_cleans";
+const CACHE_CLEANS_HELP: &str = "Cache clean operations triggered by new block environments.";
+
+const BUNDLES_SKIPPED: &str = "signet.builder.cache.bundles_skipped";
+const BUNDLES_SKIPPED_HELP: &str = "Bundles skipped because they target a past block.";
+
+const BUNDLE_ADD_ERRORS: &str = "signet.builder.cache.bundle_add_errors";
+const BUNDLE_ADD_ERRORS_HELP: &str = "Errors adding bundles to the simulation cache.";
+
+const BUNDLES_INGESTED: &str = "signet.builder.cache.bundles_ingested";
+const BUNDLES_INGESTED_HELP: &str = "Bundles successfully ingested into the simulation cache.";
+
+const TXS_INGESTED: &str = "signet.builder.cache.txs_ingested";
+const TXS_INGESTED_HELP: &str = "Transactions successfully ingested into the simulation cache.";
+
+const TX_RECOVER_FAILURES: &str = "signet.builder.cache.tx_recover_failures";
+const TX_RECOVER_FAILURES_HELP: &str = "Transaction signature recovery failures.";
+
+// -- Tx monitoring --
+
+const TX_MINE_TIME: &str = "signet.builder.tx_mine_time";
+const TX_MINE_TIME_HELP: &str = "Time in milliseconds for a submitted transaction to be mined.";
+
+const TX_SUCCEEDED: &str = "signet.builder.tx_succeeded";
+const TX_SUCCEEDED_HELP: &str = "Submitted transactions that succeeded on-chain.";
+
+const TX_REVERTED: &str = "signet.builder.tx_reverted";
+const TX_REVERTED_HELP: &str = "Submitted transactions that reverted on-chain.";
+
+const TX_NOT_MINED: &str = "signet.builder.tx_not_mined";
+const TX_NOT_MINED_HELP: &str = "Submitted transactions that were not mined within the timeout.";
+
+const RPC_ERROR: &str = "signet.builder.rpc_error";
+const RPC_ERROR_HELP: &str = "RPC errors encountered while watching submitted transactions.";
+
+// -- Quincey signing --
+
+const QUINCEY_SIGNATURES: &str = "signet.builder.quincey_signatures";
+const QUINCEY_SIGNATURES_HELP: &str = "Successful Quincey signature responses.";
+
+const QUINCEY_SIGNATURE_FAILURES: &str = "signet.builder.quincey_signature_failures";
+const QUINCEY_SIGNATURE_FAILURES_HELP: &str = "Failed Quincey signature requests.";
+
+// -- Submit --
+
+const TRANSACTIONS_PREPARED: &str = "signet.builder.submit.transactions_prepared";
+const TRANSACTIONS_PREPARED_HELP: &str = "Signed rollup block transactions ready for submission.";
+
+const EMPTY_BLOCKS: &str = "signet.builder.submit.empty_blocks";
+const EMPTY_BLOCKS_HELP: &str = "Empty blocks skipped during submission.";
+
+const BUNDLE_PREP_FAILURES: &str = "signet.builder.submit.bundle_prep_failures";
+const BUNDLE_PREP_FAILURES_HELP: &str = "Bundle preparation errors.";
+
+const RELAY_SUBMISSIONS: &str = "signet.builder.submit.relay_submissions";
+const RELAY_SUBMISSIONS_HELP: &str = "Relay submission attempts (incremented per relay).";
+
+const DEADLINE_MISSED_BEFORE_SEND: &str = "signet.builder.submit.deadline_missed_before_send";
+const DEADLINE_MISSED_BEFORE_SEND_HELP: &str =
+    "Submissions that started after the slot deadline had already passed.";
+
+const RELAY_SUCCESSES: &str = "signet.builder.submit.relay_successes";
+const RELAY_SUCCESSES_HELP: &str = "Per-relay successful bundle submissions.";
+
+const RELAY_FAILURES: &str = "signet.builder.submit.relay_failures";
+const RELAY_FAILURES_HELP: &str = "Per-relay bundle submission errors.";
+
+const RELAY_TIMEOUTS: &str = "signet.builder.submit.relay_timeouts";
+const RELAY_TIMEOUTS_HELP: &str = "Per-relay bundle submission deadline timeouts.";
+
+const ALL_RELAYS_FAILED: &str = "signet.builder.submit.all_relays_failed";
+const ALL_RELAYS_FAILED_HELP: &str = "Bundles where no relay accepted the submission.";
+
+const BUNDLES_SUBMITTED: &str = "signet.builder.submit.bundles_submitted";
+const BUNDLES_SUBMITTED_HELP: &str = "Bundles accepted by at least one relay.";
+
+const DEADLINE_MISSED: &str = "signet.builder.submit.deadline_missed";
+const DEADLINE_MISSED_HELP: &str = "Bundles accepted by relays but after the slot deadline.";
+
+const DEADLINE_MET: &str = "signet.builder.submit.deadline_met";
+const DEADLINE_MET_HELP: &str = "Bundles accepted by relays within the slot deadline.";
+
+// -- Pylon --
+
+const PYLON_SUBMISSION_FAILURES: &str = "signet.builder.pylon.submission_failures";
+const PYLON_SUBMISSION_FAILURES_HELP: &str = "Pylon sidecar submission errors.";
+
+const PYLON_SIDECARS_SUBMITTED: &str = "signet.builder.pylon.sidecars_submitted";
+const PYLON_SIDECARS_SUBMITTED_HELP: &str = "Successful Pylon sidecar submissions.";
+
+// ---------------------------------------------------------------------------
+// Lazy description registration
+// ---------------------------------------------------------------------------
+
+static DESCRIPTIONS: LazyLock<()> = LazyLock::new(|| {
+    // Block building
+    describe_counter!(BUILT_BLOCKS, BUILT_BLOCKS_HELP);
+    describe_histogram!(BUILT_BLOCKS_TX_COUNT, BUILT_BLOCKS_TX_COUNT_HELP);
+
+    // Cache polling
+    describe_counter!(TX_NONCE_STALE, TX_NONCE_STALE_HELP);
+    describe_counter!(TX_POLL_COUNT, TX_POLL_COUNT_HELP);
+    describe_counter!(TX_POLL_ERRORS, TX_POLL_ERRORS_HELP);
+    describe_histogram!(TXS_FETCHED, TXS_FETCHED_HELP);
+    describe_counter!(BUNDLE_POLL_COUNT, BUNDLE_POLL_COUNT_HELP);
+    describe_counter!(BUNDLE_POLL_ERRORS, BUNDLE_POLL_ERRORS_HELP);
+    describe_histogram!(BUNDLES_FETCHED, BUNDLES_FETCHED_HELP);
+
+    // Cache ingestion
+    describe_counter!(CACHE_CLEANS, CACHE_CLEANS_HELP);
+    describe_counter!(BUNDLES_SKIPPED, BUNDLES_SKIPPED_HELP);
+    describe_counter!(BUNDLE_ADD_ERRORS, BUNDLE_ADD_ERRORS_HELP);
+    describe_counter!(BUNDLES_INGESTED, BUNDLES_INGESTED_HELP);
+    describe_counter!(TXS_INGESTED, TXS_INGESTED_HELP);
+    describe_counter!(TX_RECOVER_FAILURES, TX_RECOVER_FAILURES_HELP);
+
+    // Tx monitoring
+    describe_histogram!(TX_MINE_TIME, TX_MINE_TIME_HELP);
+    describe_counter!(TX_SUCCEEDED, TX_SUCCEEDED_HELP);
+    describe_counter!(TX_REVERTED, TX_REVERTED_HELP);
+    describe_counter!(TX_NOT_MINED, TX_NOT_MINED_HELP);
+    describe_counter!(RPC_ERROR, RPC_ERROR_HELP);
+
+    // Quincey signing
+    describe_counter!(QUINCEY_SIGNATURES, QUINCEY_SIGNATURES_HELP);
+    describe_counter!(QUINCEY_SIGNATURE_FAILURES, QUINCEY_SIGNATURE_FAILURES_HELP);
+
+    // Submit
+    describe_counter!(TRANSACTIONS_PREPARED, TRANSACTIONS_PREPARED_HELP);
+    describe_counter!(EMPTY_BLOCKS, EMPTY_BLOCKS_HELP);
+    describe_counter!(BUNDLE_PREP_FAILURES, BUNDLE_PREP_FAILURES_HELP);
+    describe_counter!(RELAY_SUBMISSIONS, RELAY_SUBMISSIONS_HELP);
+    describe_counter!(DEADLINE_MISSED_BEFORE_SEND, DEADLINE_MISSED_BEFORE_SEND_HELP);
+    describe_counter!(RELAY_SUCCESSES, RELAY_SUCCESSES_HELP);
+    describe_counter!(RELAY_FAILURES, RELAY_FAILURES_HELP);
+    describe_counter!(RELAY_TIMEOUTS, RELAY_TIMEOUTS_HELP);
+    describe_counter!(ALL_RELAYS_FAILED, ALL_RELAYS_FAILED_HELP);
+    describe_counter!(BUNDLES_SUBMITTED, BUNDLES_SUBMITTED_HELP);
+    describe_counter!(DEADLINE_MISSED, DEADLINE_MISSED_HELP);
+    describe_counter!(DEADLINE_MET, DEADLINE_MET_HELP);
+
+    // Pylon
+    describe_counter!(PYLON_SUBMISSION_FAILURES, PYLON_SUBMISSION_FAILURES_HELP);
+    describe_counter!(PYLON_SIDECARS_SUBMITTED, PYLON_SIDECARS_SUBMITTED_HELP);
+});
+
+/// Register all metric descriptions. Call once at startup (e.g. after
+/// initializing the metrics recorder).
+pub(crate) fn init() {
+    LazyLock::force(&DESCRIPTIONS);
+}
+
+// ---------------------------------------------------------------------------
+// Public API -- Block building
+// ---------------------------------------------------------------------------
+
+/// Increment the built-blocks counter.
+pub(crate) fn inc_built_blocks() {
+    counter!(BUILT_BLOCKS).increment(1);
+}
+
+/// Record the transaction count of a built block.
+pub(crate) fn record_built_block_tx_count(count: usize) {
+    histogram!(BUILT_BLOCKS_TX_COUNT).record(count as f64);
+}
+
+// ---------------------------------------------------------------------------
+// Public API -- Cache polling
+// ---------------------------------------------------------------------------
+
+/// Increment the stale-nonce transaction counter.
+pub(crate) fn inc_tx_nonce_stale() {
+    counter!(TX_NONCE_STALE).increment(1);
+}
+
+/// Increment the transaction poll attempt counter.
+pub(crate) fn inc_tx_poll_count() {
+    counter!(TX_POLL_COUNT).increment(1);
+}
+
+/// Increment the transaction poll error counter.
+pub(crate) fn inc_tx_poll_errors() {
+    counter!(TX_POLL_ERRORS).increment(1);
+}
+
+/// Record the number of transactions fetched in a poll cycle.
+pub(crate) fn record_txs_fetched(count: usize) {
+    histogram!(TXS_FETCHED).record(count as f64);
+}
+
+/// Increment the bundle poll attempt counter.
+pub(crate) fn inc_bundle_poll_count() {
+    counter!(BUNDLE_POLL_COUNT).increment(1);
+}
+
+/// Increment the bundle poll error counter.
+pub(crate) fn inc_bundle_poll_errors() {
+    counter!(BUNDLE_POLL_ERRORS).increment(1);
+}
+
+/// Record the number of bundles fetched in a poll cycle.
+pub(crate) fn record_bundles_fetched(count: usize) {
+    histogram!(BUNDLES_FETCHED).record(count as f64);
+}
+
+// ---------------------------------------------------------------------------
+// Public API -- Cache ingestion
+// ---------------------------------------------------------------------------
+
+/// Increment the cache-clean counter.
+pub(crate) fn inc_cache_cleans() {
+    counter!(CACHE_CLEANS).increment(1);
+}
+
+/// Increment the skipped-bundle counter (bundle targets a past block).
+pub(crate) fn inc_bundles_skipped() {
+    counter!(BUNDLES_SKIPPED).increment(1);
+}
+
+/// Increment the bundle-add-error counter.
+pub(crate) fn inc_bundle_add_errors() {
+    counter!(BUNDLE_ADD_ERRORS).increment(1);
+}
+
+/// Increment the bundles-ingested counter.
+pub(crate) fn inc_bundles_ingested() {
+    counter!(BUNDLES_INGESTED).increment(1);
+}
+
+/// Increment the transactions-ingested counter.
+pub(crate) fn inc_txs_ingested() {
+    counter!(TXS_INGESTED).increment(1);
+}
+
+/// Increment the transaction signature recovery failure counter.
+pub(crate) fn inc_tx_recover_failures() {
+    counter!(TX_RECOVER_FAILURES).increment(1);
+}
+
+// ---------------------------------------------------------------------------
+// Public API -- Tx monitoring
+// ---------------------------------------------------------------------------
+
+/// Record the time for a submitted transaction to be mined.
+pub(crate) fn record_tx_mine_time(duration: std::time::Duration) {
+    histogram!(TX_MINE_TIME).record(duration.as_millis() as f64);
+}
+
+/// Increment the succeeded-transaction counter.
+pub(crate) fn inc_tx_succeeded() {
+    counter!(TX_SUCCEEDED).increment(1);
+}
+
+/// Increment the reverted-transaction counter.
+pub(crate) fn inc_tx_reverted() {
+    counter!(TX_REVERTED).increment(1);
+}
+
+/// Increment the not-mined-transaction counter.
+pub(crate) fn inc_tx_not_mined() {
+    counter!(TX_NOT_MINED).increment(1);
+}
+
+/// Increment the RPC error counter.
+pub(crate) fn inc_rpc_error() {
+    counter!(RPC_ERROR).increment(1);
+}
+
+// ---------------------------------------------------------------------------
+// Public API -- Quincey signing
+// ---------------------------------------------------------------------------
+
+/// Increment the successful Quincey signature counter.
+pub(crate) fn inc_quincey_signatures() {
+    counter!(QUINCEY_SIGNATURES).increment(1);
+}
+
+/// Increment the failed Quincey signature counter.
+pub(crate) fn inc_quincey_signature_failures() {
+    counter!(QUINCEY_SIGNATURE_FAILURES).increment(1);
+}
+
+// ---------------------------------------------------------------------------
+// Public API -- Submit
+// ---------------------------------------------------------------------------
+
+/// Increment the transactions-prepared counter.
+pub(crate) fn inc_transactions_prepared() {
+    counter!(TRANSACTIONS_PREPARED).increment(1);
+}
+
+/// Increment the empty-blocks counter.
+pub(crate) fn inc_empty_blocks() {
+    counter!(EMPTY_BLOCKS).increment(1);
+}
+
+/// Increment the bundle-prep-failures counter.
+pub(crate) fn inc_bundle_prep_failures() {
+    counter!(BUNDLE_PREP_FAILURES).increment(1);
+}
+
+/// Increment the relay submission attempt counter by `count`.
+pub(crate) fn inc_relay_submissions(count: usize) {
+    counter!(RELAY_SUBMISSIONS).increment(count as u64);
+}
+
+/// Increment the deadline-missed-before-send counter.
+pub(crate) fn inc_deadline_missed_before_send() {
+    counter!(DEADLINE_MISSED_BEFORE_SEND).increment(1);
+}
+
+/// Increment the per-relay success counter.
+pub(crate) fn inc_relay_successes() {
+    counter!(RELAY_SUCCESSES).increment(1);
+}
+
+/// Increment the per-relay failure counter.
+pub(crate) fn inc_relay_failures() {
+    counter!(RELAY_FAILURES).increment(1);
+}
+
+/// Increment the per-relay timeout counter.
+pub(crate) fn inc_relay_timeouts() {
+    counter!(RELAY_TIMEOUTS).increment(1);
+}
+
+/// Increment the all-relays-failed counter.
+pub(crate) fn inc_all_relays_failed() {
+    counter!(ALL_RELAYS_FAILED).increment(1);
+}
+
+/// Increment the bundles-submitted counter.
+pub(crate) fn inc_bundles_submitted() {
+    counter!(BUNDLES_SUBMITTED).increment(1);
+}
+
+/// Increment the deadline-missed counter.
+pub(crate) fn inc_deadline_missed() {
+    counter!(DEADLINE_MISSED).increment(1);
+}
+
+/// Increment the deadline-met counter.
+pub(crate) fn inc_deadline_met() {
+    counter!(DEADLINE_MET).increment(1);
+}
+
+// ---------------------------------------------------------------------------
+// Public API -- Pylon
+// ---------------------------------------------------------------------------
+
+/// Increment the Pylon submission failure counter.
+pub(crate) fn inc_pylon_submission_failures() {
+    counter!(PYLON_SUBMISSION_FAILURES).increment(1);
+}
+
+/// Increment the Pylon sidecars-submitted counter.
+pub(crate) fn inc_pylon_sidecars_submitted() {
+    counter!(PYLON_SIDECARS_SUBMITTED).increment(1);
+}

--- a/src/tasks/block/sim.rs
+++ b/src/tasks/block/sim.rs
@@ -6,10 +6,7 @@ use crate::{
     tasks::env::SimEnv,
 };
 use alloy::{consensus::Header, eips::Encodable2718, primitives::Bytes};
-use init4_bin_base::{
-    deps::metrics::{counter, histogram},
-    utils::calc::SlotCalculator,
-};
+use init4_bin_base::utils::calc::SlotCalculator;
 use signet_sim::{BlockBuild, BuiltBlock, SimCache};
 use signet_types::constants::SignetSystemConstants;
 use std::time::{Duration, Instant};
@@ -168,8 +165,8 @@ impl SimulatorTask {
             block_number = built_block.block_number(),
             "block simulation completed",
         );
-        counter!("signet.builder.built_blocks").increment(1);
-        histogram!("signet.builder.built_blocks.tx_count").record(built_block.tx_count() as u32);
+        crate::metrics::inc_built_blocks();
+        crate::metrics::record_built_block_tx_count(built_block.tx_count());
 
         Ok(built_block)
     }

--- a/src/tasks/cache/bundle.rs
+++ b/src/tasks/cache/bundle.rs
@@ -1,10 +1,7 @@
 //! Bundler service responsible for fetching bundles and sending them to the simulator.
 use crate::config::BuilderConfig;
 use futures_util::{TryFutureExt, TryStreamExt};
-use init4_bin_base::{
-    deps::metrics::{counter, histogram},
-    perms::tx_cache::{BuilderTxCache, BuilderTxCacheError},
-};
+use init4_bin_base::perms::tx_cache::{BuilderTxCache, BuilderTxCacheError};
 use signet_tx_cache::{TxCacheError, types::CachedBundle};
 use tokio::{
     sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
@@ -70,7 +67,7 @@ impl BundlePoller {
                 break;
             }
 
-            counter!("signet.builder.cache.bundle_poll_count").increment(1);
+            crate::metrics::inc_bundle_poll_count();
             let Ok(bundles) = self
                 .check_bundle_cache()
                 .inspect_err(|error| match error {
@@ -78,7 +75,7 @@ impl BundlePoller {
                         trace!("Not our slot to fetch bundles");
                     }
                     _ => {
-                        counter!("signet.builder.cache.bundle_poll_errors").increment(1);
+                        crate::metrics::inc_bundle_poll_errors();
                         warn!(%error, "Failed to fetch bundles from tx-cache");
                     }
                 })
@@ -91,7 +88,7 @@ impl BundlePoller {
 
             {
                 let _guard = span.entered();
-                histogram!("signet.builder.cache.bundles_fetched").record(bundles.len() as f64);
+                crate::metrics::record_bundles_fetched(bundles.len());
                 trace!(count = bundles.len(), "fetched bundles from tx-cache");
                 for bundle in bundles {
                     if let Err(err) = outbound.send(bundle) {

--- a/src/tasks/cache/task.rs
+++ b/src/tasks/cache/task.rs
@@ -1,6 +1,5 @@
 use crate::tasks::{cache::tx::ReceivedTx, env::SimEnv};
 use alloy::consensus::transaction::SignerRecoverable;
-use init4_bin_base::deps::metrics::counter;
 use signet_sim::SimCache;
 use signet_tx_cache::types::CachedBundle;
 use tokio::{
@@ -65,7 +64,7 @@ impl CacheTask {
                         cache.clean(
                             sim_env.number.to(), sim_env.timestamp.to()
                         );
-                        counter!("signet.builder.cache.cache_cleans").increment(1);
+                        crate::metrics::inc_cache_cleans();
                     }
                 }
                 Some(bundle) = self.bundles.recv() => {
@@ -85,7 +84,7 @@ impl CacheTask {
                             %bundle.id,
                             "skipping bundle insert"
                         );
-                        counter!("signet.builder.cache.bundles_skipped").increment(1);
+                        crate::metrics::inc_bundles_skipped();
                         summary.bundles_skipped_stale += 1;
                         continue;
                     }
@@ -93,11 +92,11 @@ impl CacheTask {
                     let res = cache.add_bundle(bundle.bundle, basefee);
                     // Skip bundles that fail to be added to the cache
                     if let Err(e) = res {
-                        counter!("signet.builder.cache.bundle_add_errors").increment(1);
+                        crate::metrics::inc_bundle_add_errors();
                         debug!(?e, "Failed to add bundle to cache");
                         continue;
                     }
-                    counter!("signet.builder.cache.bundles_ingested").increment(1);
+                    crate::metrics::inc_bundles_ingested();
                     summary.bundles_accepted += 1;
                 }
                 Some(received_txn) = self.txns.recv() => {
@@ -110,11 +109,11 @@ impl CacheTask {
                     match txn.try_into_recovered() {
                         Ok(recovered_tx) => {
                             cache.add_tx(recovered_tx, basefee);
-                            counter!("signet.builder.cache.txs_ingested").increment(1);
+                            crate::metrics::inc_txs_ingested();
                             summary.txs_accepted += 1;
                         }
                         Err(_) => {
-                            counter!("signet.builder.cache.tx_recover_failures").increment(1);
+                            crate::metrics::inc_tx_recover_failures();
                             debug!("Failed to recover transaction signature");
                         }
                     }

--- a/src/tasks/cache/tx.rs
+++ b/src/tasks/cache/tx.rs
@@ -5,7 +5,6 @@ use alloy::{
     providers::Provider,
 };
 use futures_util::{TryFutureExt, TryStreamExt};
-use init4_bin_base::deps::metrics::{counter, histogram};
 use signet_tx_cache::{TxCache, TxCacheError};
 use std::time::Duration;
 use tokio::{sync::mpsc, task::JoinHandle, time};
@@ -82,7 +81,7 @@ impl TxPoller {
             };
 
             if tx.nonce() < tx_count {
-                counter!("signet.builder.cache.tx_nonce_stale").increment(1);
+                crate::metrics::inc_tx_nonce_stale();
                 if outbound.send(ReceivedTx::StaleNonce).is_err() {
                     span_warn!(span, "Outbound channel closed, stopping NonceChecker task.");
                 }
@@ -112,18 +111,18 @@ impl TxPoller {
                 break;
             }
 
-            counter!("signet.builder.cache.tx_poll_count").increment(1);
+            crate::metrics::inc_tx_poll_count();
             if let Ok(transactions) = self
                 .check_tx_cache()
                 .inspect_err(|error| {
-                    counter!("signet.builder.cache.tx_poll_errors").increment(1);
+                    crate::metrics::inc_tx_poll_errors();
                     debug!(%error, "Error fetching transactions");
                 })
                 .instrument(span.clone())
                 .await
             {
                 let _guard = span.entered();
-                histogram!("signet.builder.cache.txs_fetched").record(transactions.len() as f64);
+                crate::metrics::record_txs_fetched(transactions.len());
                 trace!(count = transactions.len(), "found transactions");
                 for tx in transactions.into_iter() {
                     self.spawn_check_nonce(tx, outbound.clone());

--- a/src/tasks/metrics.rs
+++ b/src/tasks/metrics.rs
@@ -3,7 +3,6 @@ use alloy::{
     primitives::TxHash,
     providers::{PendingTransactionBuilder, PendingTransactionError, Provider as _, WatchTxError},
 };
-use init4_bin_base::deps::metrics::{counter, histogram};
 use std::time::{Duration, Instant};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{Instrument, debug, error, info_span};
@@ -50,24 +49,24 @@ impl MetricsTask {
                 Ok(receipt) => {
                     // record how long it took to mine the transaction
                     // potential improvement: use the block timestamp to calculate the time elapsed
-                    histogram!("metrics.tx_mine_time").record(start.elapsed().as_millis() as f64);
+                    crate::metrics::record_tx_mine_time(start.elapsed());
 
                     // log whether the transaction reverted
                     if receipt.status() {
-                        counter!("metrics.tx_succeeded").increment(1);
+                        crate::metrics::inc_tx_succeeded();
                         debug!("tx succeeded");
                     } else {
-                        counter!("metrics.tx_reverted").increment(1);
+                        crate::metrics::inc_tx_reverted();
                         debug!("tx reverted");
                     }
                 }
                 Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout)) => {
                     // log that the transaction timed out
-                    counter!("metrics.tx_not_mined").increment(1);
+                    crate::metrics::inc_tx_not_mined();
                     debug!("tx not mined");
                 }
                 Err(e) => {
-                    counter!("metrics.rpc_error").increment(1);
+                    crate::metrics::inc_rpc_error();
                     error!(error = ?e, "rpc error");
                 }
             }

--- a/src/tasks/submit/prep.rs
+++ b/src/tasks/submit/prep.rs
@@ -14,7 +14,6 @@ use alloy::{
     sol_types::SolCall,
 };
 use futures_util::FutureExt;
-use init4_bin_base::deps::metrics::counter;
 use signet_sim::BuiltBlock;
 use signet_types::{SignRequest, SignResponse};
 use signet_zenith::Zenith;
@@ -83,9 +82,9 @@ impl<'a> SubmitPrep<'a> {
                     self.quincey
                         .get_signature(sig_request)
                         .await
-                        .inspect(|_| counter!("signet.builder.quincey_signatures").increment(1))
+                        .inspect(|_| crate::metrics::inc_quincey_signatures())
                         .inspect_err(|err| {
-                            counter!("signet.builder.quincey_signature_failures").increment(1);
+                            crate::metrics::inc_quincey_signature_failures();
                             if let QuinceyError::NotOurSlot = err {
                                 warn!("Quincey indicated not our slot to sign");
                             } else {

--- a/src/tasks/submit/task.rs
+++ b/src/tasks/submit/task.rs
@@ -31,7 +31,7 @@ use alloy::{
     rpc::types::mev::EthSendBundle,
 };
 use futures_util::stream::{FuturesUnordered, StreamExt};
-use init4_bin_base::{deps::metrics::counter, utils::signer::LocalOrAws};
+use init4_bin_base::utils::signer::LocalOrAws;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -159,7 +159,7 @@ impl SubmitTask {
 
     /// Tracks the outbound transaction hash and increments submission metrics.
     fn track_outbound_tx(&self, envelope: &TxEnvelope) {
-        counter!("signet.builder.submit.transactions_prepared").increment(1);
+        crate::metrics::inc_transactions_prepared();
         let hash = *envelope.tx_hash();
         if self.outbound.send(hash).is_err() {
             debug!("outbound channel closed, could not track tx hash");
@@ -189,7 +189,7 @@ impl SubmitTask {
             let deadline = self.calculate_submit_deadline();
 
             if sim_result.block.is_empty() {
-                counter!("signet.builder.submit.empty_blocks").increment(1);
+                crate::metrics::inc_empty_blocks();
                 span_debug!(span, "received empty block - skipping");
                 continue;
             }
@@ -198,7 +198,7 @@ impl SubmitTask {
             let bundle = match self.prepare(&sim_result).instrument(span.clone()).await {
                 Ok(bundle) => bundle,
                 Err(error) => {
-                    counter!("signet.builder.submit.bundle_prep_failures").increment(1);
+                    crate::metrics::inc_bundle_prep_failures();
                     span_debug!(span, %error, "bundle preparation failed");
                     continue;
                 }
@@ -333,13 +333,13 @@ impl Submission {
     /// results from faster relays.
     async fn submit_to_relays(&self) -> Vec<RelayOutcome> {
         let n_relays = self.relays.len();
-        counter!("signet.builder.submit.relay_submissions").increment(n_relays as u64);
+        crate::metrics::inc_relay_submissions(n_relays);
 
         let now = Instant::now();
         let timeout_dur = if now > self.deadline {
             let late_by = now.duration_since(self.deadline);
             warn!(?late_by, "submission started AFTER deadline; attempting anyway");
-            counter!("signet.builder.submit.deadline_missed_before_send").increment(1);
+            crate::metrics::inc_deadline_missed_before_send();
             LATE_SUBMISSION_TIMEOUT
         } else {
             self.deadline.duration_since(now)
@@ -375,33 +375,33 @@ impl Submission {
         for outcome in outcomes {
             match outcome {
                 RelayOutcome::Success => {
-                    counter!("signet.builder.submit.relay_successes").increment(1);
+                    crate::metrics::inc_relay_successes();
                     successes += 1;
                 }
                 RelayOutcome::Failure => {
-                    counter!("signet.builder.submit.relay_failures").increment(1);
+                    crate::metrics::inc_relay_failures();
                     failures += 1;
                 }
                 RelayOutcome::Timeout => {
-                    counter!("signet.builder.submit.relay_timeouts").increment(1);
+                    crate::metrics::inc_relay_timeouts();
                     timeouts += 1;
                 }
             }
         }
 
         if successes == 0 {
-            counter!("signet.builder.submit.all_relays_failed").increment(1);
+            crate::metrics::inc_all_relays_failed();
             error!(
                 failures,
                 timeouts, n_relays, "all relay submissions failed - bundle may not land"
             );
         } else {
-            counter!("signet.builder.submit.bundles_submitted").increment(1);
+            crate::metrics::inc_bundles_submitted();
             if Instant::now() > self.deadline {
-                counter!("signet.builder.submit.deadline_missed").increment(1);
+                crate::metrics::inc_deadline_missed();
                 warn!(successes, failures, timeouts, "bundle accepted by relays AFTER deadline");
             } else {
-                counter!("signet.builder.submit.deadline_met").increment(1);
+                crate::metrics::inc_deadline_met();
                 info!(
                     successes,
                     failures, timeouts, n_relays, "bundle submitted to relays within deadline"
@@ -416,12 +416,12 @@ impl Submission {
     /// submission failed or timed out.
     async fn submit_to_pylon(&self) {
         if let Err(err) = self.pylon.post_blob_tx(self.block_tx.clone()).await {
-            counter!("signet.builder.pylon.submission_failures").increment(1);
+            crate::metrics::inc_pylon_submission_failures();
             warn!(%err, "pylon submission failed");
             return;
         }
 
-        counter!("signet.builder.pylon.sidecars_submitted").increment(1);
+        crate::metrics::inc_pylon_sidecars_submitted();
         debug!("posted sidecar to pylon");
     }
 }


### PR DESCRIPTION
## Description

This centralizes all the metrics functionality into a single module, in line with how this is done in other signet crates.

## Related Issue

Closes ENG-1966.

## Testing

- [x] `make fmt` passes
- [x] `make clippy` passes
- [x] `make test` passes
