### PR TITLE
feat: replace BundlePoller polling with SSE streaming

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,7 +34,10 @@ const TXS_FETCHED: &str = "signet.builder.cache.txs_fetched";
 const TXS_FETCHED_HELP: &str = "Transactions fetched per poll cycle.";
 
 const SSE_RECONNECT_ATTEMPTS: &str = "signet.builder.cache.sse_reconnect_attempts";
-const SSE_RECONNECT_ATTEMPTS_HELP: &str = "SSE transaction stream reconnect attempts.";
+const SSE_RECONNECT_ATTEMPTS_HELP: &str = "SSE stream reconnect attempts.";
+
+const SSE_SUBSCRIBE_ERRORS: &str = "signet.builder.cache.sse_subscribe_errors";
+const SSE_SUBSCRIBE_ERRORS_HELP: &str = "SSE stream subscription failures.";
 
 const BUNDLE_POLL_COUNT: &str = "signet.builder.cache.bundle_poll_count";
 const BUNDLE_POLL_COUNT_HELP: &str = "Bundle cache poll attempts.";
@@ -152,6 +155,7 @@ static DESCRIPTIONS: LazyLock<()> = LazyLock::new(|| {
     describe_counter!(TX_POLL_ERRORS, TX_POLL_ERRORS_HELP);
     describe_histogram!(TXS_FETCHED, TXS_FETCHED_HELP);
     describe_counter!(SSE_RECONNECT_ATTEMPTS, SSE_RECONNECT_ATTEMPTS_HELP);
+    describe_counter!(SSE_SUBSCRIBE_ERRORS, SSE_SUBSCRIBE_ERRORS_HELP);
     describe_counter!(BUNDLE_POLL_COUNT, BUNDLE_POLL_COUNT_HELP);
     describe_counter!(BUNDLE_POLL_ERRORS, BUNDLE_POLL_ERRORS_HELP);
     describe_histogram!(BUNDLES_FETCHED, BUNDLES_FETCHED_HELP);
@@ -241,6 +245,11 @@ pub(crate) fn record_txs_fetched(count: usize) {
 /// Increment the SSE reconnect attempts counter.
 pub(crate) fn inc_sse_reconnect_attempts() {
     counter!(SSE_RECONNECT_ATTEMPTS).increment(1);
+}
+
+/// Increment the SSE subscribe error counter.
+pub(crate) fn inc_sse_subscribe_errors() {
+    counter!(SSE_SUBSCRIBE_ERRORS).increment(1);
 }
 
 /// Increment the bundle poll attempt counter.

--- a/src/tasks/cache/bundle.rs
+++ b/src/tasks/cache/bundle.rs
@@ -143,13 +143,13 @@ impl BundlePoller {
             .inspect(
                 |_| debug!(url = %self.config.tx_pool_url, "SSE bundle subscription established"),
             )
-            .inspect_err(|error| {
-                crate::metrics::inc_sse_subscribe_errors();
-                match error {
-                    BuilderTxCacheError::TxCache(TxCacheError::NotOurSlot) => {
-                        trace!("Not our slot to subscribe to bundles");
-                    }
-                    _ => warn!(%error, "Failed to open SSE bundle subscription"),
+            .inspect_err(|error| match error {
+                BuilderTxCacheError::TxCache(TxCacheError::NotOurSlot) => {
+                    trace!("Not our slot to subscribe to bundles");
+                }
+                _ => {
+                    crate::metrics::inc_sse_subscribe_errors();
+                    warn!(%error, "Failed to open SSE bundle subscription");
                 }
             })
             .ok()
@@ -188,6 +188,23 @@ impl BundlePoller {
         }
     }
 
+    /// Reconnects and swaps in the fresh stream, or returns `Break` if the
+    /// outbound channel closed during the reconnect loop.
+    async fn try_reconnect(
+        &mut self,
+        outbound: &mpsc::UnboundedSender<CachedBundle>,
+        backoff: &mut Duration,
+        stream: &mut SseStream,
+    ) -> ControlFlow<()> {
+        match self.reconnect(outbound, backoff).await {
+            Some(s) => {
+                *stream = s;
+                ControlFlow::Continue(())
+            }
+            None => ControlFlow::Break(()),
+        }
+    }
+
     /// Returns `Break` when the outbound channel has closed and the task
     /// should shut down.
     async fn handle_sse_item(
@@ -205,23 +222,17 @@ impl BundlePoller {
                     return ControlFlow::Break(());
                 }
                 Self::spawn_check_bundle_nonces(bundle, outbound.clone());
+                ControlFlow::Continue(())
             }
             Some(Err(error)) => {
                 warn!(%error, "SSE bundle stream interrupted, reconnecting");
-                let Some(s) = self.reconnect(outbound, backoff).await else {
-                    return ControlFlow::Break(());
-                };
-                *stream = s;
+                self.try_reconnect(outbound, backoff, stream).await
             }
             None => {
                 warn!("SSE bundle stream ended, reconnecting");
-                let Some(s) = self.reconnect(outbound, backoff).await else {
-                    return ControlFlow::Break(());
-                };
-                *stream = s;
+                self.try_reconnect(outbound, backoff, stream).await
             }
         }
-        ControlFlow::Continue(())
     }
 
     async fn task_future(mut self, outbound: mpsc::UnboundedSender<CachedBundle>) {

--- a/src/tasks/cache/bundle.rs
+++ b/src/tasks/cache/bundle.rs
@@ -1,60 +1,72 @@
 //! Bundler service responsible for fetching bundles and sending them to the simulator.
-use crate::config::BuilderConfig;
-use futures_util::{TryFutureExt, TryStreamExt};
+use crate::{config::BuilderConfig, tasks::env::SimEnv};
+use futures_util::{Stream, StreamExt, TryFutureExt, TryStreamExt};
 use init4_bin_base::perms::tx_cache::{BuilderTxCache, BuilderTxCacheError};
 use signet_sim::{ProviderStateSource, SimItemValidity, check_bundle_tx_list};
 use signet_tx_cache::{TxCacheError, types::CachedBundle};
+use std::{ops::ControlFlow, pin::Pin, time::Duration};
 use tokio::{
-    sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
+    sync::{mpsc, watch},
     task::JoinHandle,
-    time::{self, Duration},
+    time,
 };
-use tracing::{Instrument, debug_span, trace, trace_span, warn};
+use tracing::{Instrument, debug, debug_span, trace, trace_span, warn};
 
-/// Poll interval for the bundle poller in milliseconds.
-const POLL_INTERVAL_MS: u64 = 1000;
+type SseStream = Pin<Box<dyn Stream<Item = Result<CachedBundle, BuilderTxCacheError>> + Send>>;
 
-/// The BundlePoller polls the tx-pool for bundles.
+const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
+
+/// The BundlePoller fetches bundles from the tx-pool on startup and on each
+/// block environment change, and subscribes to an SSE stream for real-time
+/// delivery of new bundles in between.
 #[derive(Debug)]
 pub struct BundlePoller {
     /// The builder configuration values.
     config: &'static BuilderConfig,
-
     /// Client for the tx cache.
     tx_cache: BuilderTxCache,
-
-    /// Defines the interval at which the bundler polls the tx-pool for bundles.
-    poll_interval_ms: u64,
+    /// Receiver for block environment updates, used to trigger refetches.
+    envs: watch::Receiver<Option<SimEnv>>,
 }
 
-impl Default for BundlePoller {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Implements a poller for the block builder to pull bundles from the tx-pool.
 impl BundlePoller {
-    /// Creates a new BundlePoller from the provided builder config.
-    pub fn new() -> Self {
-        Self::new_with_poll_interval_ms(POLL_INTERVAL_MS)
-    }
-
-    /// Creates a new BundlePoller from the provided builder config and with the specified poll interval in ms.
-    pub fn new_with_poll_interval_ms(poll_interval_ms: u64) -> Self {
+    /// Returns a new [`BundlePoller`] with the given block environment receiver.
+    pub fn new(envs: watch::Receiver<Option<SimEnv>>) -> Self {
         let config = crate::config();
         let tx_cache = BuilderTxCache::new(config.tx_pool_url.clone(), config.oauth_token());
-        Self { config, tx_cache, poll_interval_ms }
+        Self { config, tx_cache, envs }
     }
 
-    /// Returns the poll duration as a [`Duration`].
-    const fn poll_duration(&self) -> Duration {
-        Duration::from_millis(self.poll_interval_ms)
-    }
+    async fn full_fetch(&self, outbound: &mpsc::UnboundedSender<CachedBundle>) {
+        let span = trace_span!("BundlePoller::full_fetch", url = %self.config.tx_pool_url);
 
-    /// Fetches all bundles from the tx-cache, paginating through all available pages.
-    pub async fn check_bundle_cache(&self) -> Result<Vec<CachedBundle>, BuilderTxCacheError> {
-        self.tx_cache.stream_bundles().try_collect().await
+        crate::metrics::inc_bundle_poll_count();
+        if let Ok(bundles) = self
+            .tx_cache
+            .stream_bundles()
+            .try_collect::<Vec<_>>()
+            // NotOurSlot is expected whenever the builder isn't slot-permissioned;
+            // don't bump the error counter or warn.
+            .inspect_err(|error| match error {
+                BuilderTxCacheError::TxCache(TxCacheError::NotOurSlot) => {
+                    trace!("Not our slot to fetch bundles");
+                }
+                _ => {
+                    crate::metrics::inc_bundle_poll_errors();
+                    warn!(%error, "Failed to fetch bundles from tx-cache");
+                }
+            })
+            .instrument(span.clone())
+            .await
+        {
+            let _guard = span.entered();
+            crate::metrics::record_bundles_fetched(bundles.len());
+            trace!(count = bundles.len(), "found bundles");
+            for bundle in bundles {
+                Self::spawn_check_bundle_nonces(bundle, outbound.clone());
+            }
+        }
     }
 
     /// Spawns a tokio task to check the validity of all host transactions in a
@@ -62,7 +74,10 @@ impl BundlePoller {
     ///
     /// Uses [`check_bundle_tx_list`] from `signet-sim` to validate host tx nonces
     /// and balance against the host chain. Drops bundles that are not currently valid.
-    fn spawn_check_bundle_nonces(bundle: CachedBundle, outbound: UnboundedSender<CachedBundle>) {
+    fn spawn_check_bundle_nonces(
+        bundle: CachedBundle,
+        outbound: mpsc::UnboundedSender<CachedBundle>,
+    ) {
         let span = debug_span!("check_bundle_nonces", bundle_id = %bundle.id);
         tokio::spawn(async move {
             let recovered = match bundle.bundle.try_to_recovered() {
@@ -114,55 +129,107 @@ impl BundlePoller {
         });
     }
 
-    async fn task_future(self, outbound: UnboundedSender<CachedBundle>) {
-        loop {
-            let span = trace_span!("BundlePoller::loop", url = %self.config.tx_pool_url);
+    /// Returns an empty stream on connection failure so the caller can handle
+    /// reconnection uniformly.
+    async fn subscribe(&self) -> SseStream {
+        self.tx_cache
+            .subscribe_bundles()
+            .await
+            .inspect(
+                |_| debug!(url = %self.config.tx_pool_url, "SSE bundle subscription established"),
+            )
+            .inspect_err(|error| match error {
+                BuilderTxCacheError::TxCache(TxCacheError::NotOurSlot) => {
+                    trace!("Not our slot to subscribe to bundles");
+                }
+                _ => warn!(%error, "Failed to open SSE bundle subscription"),
+            })
+            .map(|s| Box::pin(s) as SseStream)
+            .unwrap_or_else(|_| Box::pin(futures_util::stream::empty()))
+    }
 
-            // Check this here to avoid making the web request if we know
-            // we don't need the results.
-            if outbound.is_closed() {
-                span.in_scope(|| trace!("No receivers left, shutting down"));
-                break;
+    /// Runs a full refetch concurrently with re-subscribing, to cover any
+    /// items missed while disconnected.
+    async fn reconnect(
+        &mut self,
+        outbound: &mpsc::UnboundedSender<CachedBundle>,
+        backoff: &mut Duration,
+    ) -> SseStream {
+        tokio::select! {
+            // Biased: a block env change wins over the backoff sleep. An env
+            // change triggers a full refetch below anyway, which supersedes the
+            // sleep-then-reconnect path — so there's no point waiting out the
+            // backoff.
+            biased;
+            _ = self.envs.changed() => {}
+            _ = time::sleep(*backoff) => {}
+        }
+        *backoff = (*backoff * 2).min(MAX_RECONNECT_BACKOFF);
+        let (_, stream) = tokio::join!(self.full_fetch(outbound), self.subscribe());
+        stream
+    }
+
+    /// Returns `Break` when the outbound channel has closed and the task
+    /// should shut down.
+    async fn handle_sse_item(
+        &mut self,
+        item: Option<Result<CachedBundle, BuilderTxCacheError>>,
+        outbound: &mpsc::UnboundedSender<CachedBundle>,
+        backoff: &mut Duration,
+        stream: &mut SseStream,
+    ) -> ControlFlow<()> {
+        match item {
+            Some(Ok(bundle)) => {
+                *backoff = INITIAL_RECONNECT_BACKOFF;
+                if outbound.is_closed() {
+                    trace!("No receivers left, shutting down");
+                    return ControlFlow::Break(());
+                }
+                Self::spawn_check_bundle_nonces(bundle, outbound.clone());
             }
+            Some(Err(error)) => {
+                warn!(%error, "SSE bundle stream interrupted, reconnecting");
+                *stream = self.reconnect(outbound, backoff).await;
+            }
+            None => {
+                warn!("SSE bundle stream ended, reconnecting");
+                *stream = self.reconnect(outbound, backoff).await;
+            }
+        }
+        ControlFlow::Continue(())
+    }
 
-            crate::metrics::inc_bundle_poll_count();
-            let Ok(bundles) = self
-                .check_bundle_cache()
-                .inspect_err(|error| match error {
-                    BuilderTxCacheError::TxCache(TxCacheError::NotOurSlot) => {
-                        trace!("Not our slot to fetch bundles");
-                    }
-                    _ => {
-                        crate::metrics::inc_bundle_poll_errors();
-                        warn!(%error, "Failed to fetch bundles from tx-cache");
-                    }
-                })
-                .instrument(span.clone())
-                .await
-            else {
-                time::sleep(self.poll_duration()).await;
-                continue;
-            };
+    async fn task_future(mut self, outbound: mpsc::UnboundedSender<CachedBundle>) {
+        let (_, mut sse_stream) = tokio::join!(self.full_fetch(&outbound), self.subscribe());
+        let mut backoff = INITIAL_RECONNECT_BACKOFF;
 
-            {
-                let _guard = span.entered();
-                crate::metrics::record_bundles_fetched(bundles.len());
-                trace!(count = bundles.len(), "fetched bundles from tx-cache");
-                for bundle in bundles {
-                    Self::spawn_check_bundle_nonces(bundle, outbound.clone());
+        loop {
+            tokio::select! {
+                item = sse_stream.next() => {
+                    if self
+                        .handle_sse_item(item, &outbound, &mut backoff, &mut sse_stream)
+                        .await
+                        .is_break()
+                    {
+                        break;
+                    }
+                }
+                res = self.envs.changed() => {
+                    if res.is_err() {
+                        debug!("Block env channel closed, shutting down");
+                        break;
+                    }
+                    trace!("Block env changed, refetching all bundles");
+                    self.full_fetch(&outbound).await;
                 }
             }
-
-            time::sleep(self.poll_duration()).await;
         }
     }
 
-    /// Spawns a task that sends bundles it finds to its channel sender.
-    pub fn spawn(self) -> (UnboundedReceiver<CachedBundle>, JoinHandle<()>) {
-        let (outbound, inbound) = unbounded_channel();
-
+    /// Spawns the task future and returns a receiver for bundles it finds.
+    pub fn spawn(self) -> (mpsc::UnboundedReceiver<CachedBundle>, JoinHandle<()>) {
+        let (outbound, inbound) = mpsc::unbounded_channel();
         let jh = tokio::spawn(self.task_future(outbound));
-
         (inbound, jh)
     }
 }

--- a/src/tasks/cache/bundle.rs
+++ b/src/tasks/cache/bundle.rs
@@ -185,7 +185,6 @@ impl BundlePoller {
             if let Some(stream) = stream {
                 return Some(stream);
             }
-            // subscribe failed; loop with longer backoff (no extra warn).
         }
     }
 
@@ -209,17 +208,17 @@ impl BundlePoller {
             }
             Some(Err(error)) => {
                 warn!(%error, "SSE bundle stream interrupted, reconnecting");
-                match self.reconnect(outbound, backoff).await {
-                    Some(s) => *stream = s,
-                    None => return ControlFlow::Break(()),
-                }
+                let Some(s) = self.reconnect(outbound, backoff).await else {
+                    return ControlFlow::Break(());
+                };
+                *stream = s;
             }
             None => {
                 warn!("SSE bundle stream ended, reconnecting");
-                match self.reconnect(outbound, backoff).await {
-                    Some(s) => *stream = s,
-                    None => return ControlFlow::Break(()),
-                }
+                let Some(s) = self.reconnect(outbound, backoff).await else {
+                    return ControlFlow::Break(());
+                };
+                *stream = s;
             }
         }
         ControlFlow::Continue(())
@@ -230,7 +229,7 @@ impl BundlePoller {
         fields(url = %self.config.tx_pool_url, block_number = tracing::field::Empty),
     )]
     async fn task_future(mut self, outbound: mpsc::UnboundedSender<CachedBundle>) {
-        record_block_number(&self.envs);
+        self.record_block_number();
 
         let (_, sub) = tokio::join!(self.fetch_and_forward(&outbound), self.subscribe());
         let mut backoff = INITIAL_RECONNECT_BACKOFF;
@@ -262,11 +261,17 @@ impl BundlePoller {
                         debug!("Block env channel closed, shutting down");
                         break;
                     }
-                    record_block_number(&self.envs);
+                    self.record_block_number();
                     debug!("Block env changed, refetching all bundles");
                     self.fetch_and_forward(&outbound).await;
                 }
             }
+        }
+    }
+
+    fn record_block_number(&self) {
+        if let Some(env) = self.envs.borrow().as_ref() {
+            Span::current().record("block_number", env.rollup_block_number());
         }
     }
 
@@ -275,11 +280,5 @@ impl BundlePoller {
         let (outbound, inbound) = mpsc::unbounded_channel();
         let jh = tokio::spawn(self.task_future(outbound));
         (inbound, jh)
-    }
-}
-
-fn record_block_number(envs: &watch::Receiver<Option<SimEnv>>) {
-    if let Some(env) = envs.borrow().as_ref() {
-        Span::current().record("block_number", env.rollup_env().number.to::<u64>());
     }
 }

--- a/src/tasks/cache/bundle.rs
+++ b/src/tasks/cache/bundle.rs
@@ -10,7 +10,7 @@ use tokio::{
     task::JoinHandle,
     time,
 };
-use tracing::{Instrument, debug, debug_span, trace, trace_span, warn};
+use tracing::{Instrument, Span, debug, debug_span, instrument, trace, warn};
 
 type SseStream = Pin<Box<dyn Stream<Item = Result<CachedBundle, BuilderTxCacheError>> + Send>>;
 
@@ -47,8 +47,6 @@ impl BundlePoller {
     /// Fetches all bundles from the cache and forwards each to the outbound
     /// channel. Records poll metrics around the fetch.
     async fn fetch_and_forward(&self, outbound: &mpsc::UnboundedSender<CachedBundle>) {
-        let span = trace_span!("BundlePoller::fetch_and_forward", url = %self.config.tx_pool_url);
-
         crate::metrics::inc_bundle_poll_count();
         // NotOurSlot is expected whenever the builder isn't slot-permissioned;
         // don't bump the error counter or warn.
@@ -63,13 +61,11 @@ impl BundlePoller {
                     warn!(%error, "Failed to fetch bundles from tx-cache");
                 }
             })
-            .instrument(span.clone())
             .await
         else {
             return;
         };
 
-        let _guard = span.entered();
         crate::metrics::record_bundles_fetched(bundles.len());
         trace!(count = bundles.len(), "found bundles");
         for bundle in bundles {
@@ -137,44 +133,60 @@ impl BundlePoller {
         });
     }
 
-    /// Returns an empty stream on connection failure so the caller can handle
-    /// reconnection uniformly.
-    async fn subscribe(&self) -> SseStream {
+    /// Returns `None` on connection failure; the caller is responsible for
+    /// scheduling a retry. Avoids the empty-stream sentinel pattern that
+    /// would double-log "stream ended" on a failure that never opened.
+    async fn subscribe(&self) -> Option<SseStream> {
         self.tx_cache
             .subscribe_bundles()
             .await
             .inspect(
                 |_| debug!(url = %self.config.tx_pool_url, "SSE bundle subscription established"),
             )
-            .inspect_err(|error| match error {
-                BuilderTxCacheError::TxCache(TxCacheError::NotOurSlot) => {
-                    trace!("Not our slot to subscribe to bundles");
+            .inspect_err(|error| {
+                crate::metrics::inc_sse_subscribe_errors();
+                match error {
+                    BuilderTxCacheError::TxCache(TxCacheError::NotOurSlot) => {
+                        trace!("Not our slot to subscribe to bundles");
+                    }
+                    _ => warn!(%error, "Failed to open SSE bundle subscription"),
                 }
-                _ => warn!(%error, "Failed to open SSE bundle subscription"),
             })
+            .ok()
             .map(|s| Box::pin(s) as SseStream)
-            .unwrap_or_else(|_| Box::pin(futures_util::stream::empty()))
     }
 
-    /// Runs a full refetch concurrently with re-subscribing, to cover any
-    /// items missed while disconnected.
+    /// Loops with exponential backoff until either a fresh SSE stream is
+    /// established (returned as `Some`) or the outbound channel is closed
+    /// (returned as `None`, signalling the task should shut down). Runs a
+    /// full refetch alongside each subscribe attempt to cover items missed
+    /// while disconnected.
     async fn reconnect(
         &mut self,
         outbound: &mpsc::UnboundedSender<CachedBundle>,
         backoff: &mut Duration,
-    ) -> SseStream {
-        tokio::select! {
-            // Biased: a block env change wins over the backoff sleep. An env
-            // change triggers a full refetch below anyway, which supersedes the
-            // sleep-then-reconnect path — so there's no point waiting out the
-            // backoff.
-            biased;
-            _ = self.envs.changed() => {}
-            _ = time::sleep(*backoff) => {}
+    ) -> Option<SseStream> {
+        loop {
+            if outbound.is_closed() {
+                return None;
+            }
+            crate::metrics::inc_sse_reconnect_attempts();
+            tokio::select! {
+                // Biased: a block env change wins over the backoff sleep. An env
+                // change triggers a full refetch below anyway, which supersedes the
+                // sleep-then-reconnect path — so there's no point waiting out the
+                // backoff.
+                biased;
+                _ = self.envs.changed() => {}
+                _ = time::sleep(*backoff) => {}
+            }
+            *backoff = (*backoff * 2).min(MAX_RECONNECT_BACKOFF);
+            let (_, stream) = tokio::join!(self.fetch_and_forward(outbound), self.subscribe());
+            if let Some(stream) = stream {
+                return Some(stream);
+            }
+            // subscribe failed; loop with longer backoff (no extra warn).
         }
-        *backoff = (*backoff * 2).min(MAX_RECONNECT_BACKOFF);
-        let (_, stream) = tokio::join!(self.fetch_and_forward(outbound), self.subscribe());
-        stream
     }
 
     /// Returns `Break` when the outbound channel has closed and the task
@@ -197,21 +209,44 @@ impl BundlePoller {
             }
             Some(Err(error)) => {
                 warn!(%error, "SSE bundle stream interrupted, reconnecting");
-                *stream = self.reconnect(outbound, backoff).await;
+                match self.reconnect(outbound, backoff).await {
+                    Some(s) => *stream = s,
+                    None => return ControlFlow::Break(()),
+                }
             }
             None => {
                 warn!("SSE bundle stream ended, reconnecting");
-                *stream = self.reconnect(outbound, backoff).await;
+                match self.reconnect(outbound, backoff).await {
+                    Some(s) => *stream = s,
+                    None => return ControlFlow::Break(()),
+                }
             }
         }
         ControlFlow::Continue(())
     }
 
+    #[instrument(
+        skip_all,
+        fields(url = %self.config.tx_pool_url, block_number = tracing::field::Empty),
+    )]
     async fn task_future(mut self, outbound: mpsc::UnboundedSender<CachedBundle>) {
-        let (_, mut sse_stream) = tokio::join!(self.fetch_and_forward(&outbound), self.subscribe());
+        record_block_number(&self.envs);
+
+        let (_, sub) = tokio::join!(self.fetch_and_forward(&outbound), self.subscribe());
         let mut backoff = INITIAL_RECONNECT_BACKOFF;
+        let mut sse_stream = match sub {
+            Some(s) => s,
+            None => match self.reconnect(&outbound, &mut backoff).await {
+                Some(s) => s,
+                None => return,
+            },
+        };
 
         loop {
+            if outbound.is_closed() {
+                debug!("Outbound channel closed, shutting down");
+                break;
+            }
             tokio::select! {
                 item = sse_stream.next() => {
                     if self
@@ -227,7 +262,8 @@ impl BundlePoller {
                         debug!("Block env channel closed, shutting down");
                         break;
                     }
-                    trace!("Block env changed, refetching all bundles");
+                    record_block_number(&self.envs);
+                    debug!("Block env changed, refetching all bundles");
                     self.fetch_and_forward(&outbound).await;
                 }
             }
@@ -239,5 +275,11 @@ impl BundlePoller {
         let (outbound, inbound) = mpsc::unbounded_channel();
         let jh = tokio::spawn(self.task_future(outbound));
         (inbound, jh)
+    }
+}
+
+fn record_block_number(envs: &watch::Receiver<Option<SimEnv>>) {
+    if let Some(env) = envs.borrow().as_ref() {
+        Span::current().record("block_number", env.rollup_env().number.to::<u64>());
     }
 }

--- a/src/tasks/cache/bundle.rs
+++ b/src/tasks/cache/bundle.rs
@@ -38,16 +38,22 @@ impl BundlePoller {
         Self { config, tx_cache, envs }
     }
 
-    async fn full_fetch(&self, outbound: &mpsc::UnboundedSender<CachedBundle>) {
-        let span = trace_span!("BundlePoller::full_fetch", url = %self.config.tx_pool_url);
+    /// Pulls every bundle currently in the cache, paginating until the stream
+    /// is exhausted. Pure fetch — no metrics, no forwarding.
+    async fn check_bundle_cache(&self) -> Result<Vec<CachedBundle>, BuilderTxCacheError> {
+        self.tx_cache.stream_bundles().try_collect().await
+    }
+
+    /// Fetches all bundles from the cache and forwards each to the outbound
+    /// channel. Records poll metrics around the fetch.
+    async fn fetch_and_forward(&self, outbound: &mpsc::UnboundedSender<CachedBundle>) {
+        let span = trace_span!("BundlePoller::fetch_and_forward", url = %self.config.tx_pool_url);
 
         crate::metrics::inc_bundle_poll_count();
-        if let Ok(bundles) = self
-            .tx_cache
-            .stream_bundles()
-            .try_collect::<Vec<_>>()
-            // NotOurSlot is expected whenever the builder isn't slot-permissioned;
-            // don't bump the error counter or warn.
+        // NotOurSlot is expected whenever the builder isn't slot-permissioned;
+        // don't bump the error counter or warn.
+        let Ok(bundles) = self
+            .check_bundle_cache()
             .inspect_err(|error| match error {
                 BuilderTxCacheError::TxCache(TxCacheError::NotOurSlot) => {
                     trace!("Not our slot to fetch bundles");
@@ -59,13 +65,15 @@ impl BundlePoller {
             })
             .instrument(span.clone())
             .await
-        {
-            let _guard = span.entered();
-            crate::metrics::record_bundles_fetched(bundles.len());
-            trace!(count = bundles.len(), "found bundles");
-            for bundle in bundles {
-                Self::spawn_check_bundle_nonces(bundle, outbound.clone());
-            }
+        else {
+            return;
+        };
+
+        let _guard = span.entered();
+        crate::metrics::record_bundles_fetched(bundles.len());
+        trace!(count = bundles.len(), "found bundles");
+        for bundle in bundles {
+            Self::spawn_check_bundle_nonces(bundle, outbound.clone());
         }
     }
 
@@ -165,7 +173,7 @@ impl BundlePoller {
             _ = time::sleep(*backoff) => {}
         }
         *backoff = (*backoff * 2).min(MAX_RECONNECT_BACKOFF);
-        let (_, stream) = tokio::join!(self.full_fetch(outbound), self.subscribe());
+        let (_, stream) = tokio::join!(self.fetch_and_forward(outbound), self.subscribe());
         stream
     }
 
@@ -200,7 +208,7 @@ impl BundlePoller {
     }
 
     async fn task_future(mut self, outbound: mpsc::UnboundedSender<CachedBundle>) {
-        let (_, mut sse_stream) = tokio::join!(self.full_fetch(&outbound), self.subscribe());
+        let (_, mut sse_stream) = tokio::join!(self.fetch_and_forward(&outbound), self.subscribe());
         let mut backoff = INITIAL_RECONNECT_BACKOFF;
 
         loop {
@@ -220,7 +228,7 @@ impl BundlePoller {
                         break;
                     }
                     trace!("Block env changed, refetching all bundles");
-                    self.full_fetch(&outbound).await;
+                    self.fetch_and_forward(&outbound).await;
                 }
             }
         }

--- a/src/tasks/cache/bundle.rs
+++ b/src/tasks/cache/bundle.rs
@@ -10,7 +10,7 @@ use tokio::{
     task::JoinHandle,
     time,
 };
-use tracing::{Instrument, Span, debug, debug_span, instrument, trace, warn};
+use tracing::{Instrument, debug, debug_span, trace, warn};
 
 type SseStream = Pin<Box<dyn Stream<Item = Result<CachedBundle, BuilderTxCacheError>> + Send>>;
 
@@ -224,13 +224,7 @@ impl BundlePoller {
         ControlFlow::Continue(())
     }
 
-    #[instrument(
-        skip_all,
-        fields(url = %self.config.tx_pool_url, block_number = tracing::field::Empty),
-    )]
     async fn task_future(mut self, outbound: mpsc::UnboundedSender<CachedBundle>) {
-        self.record_block_number();
-
         let (_, sub) = tokio::join!(self.fetch_and_forward(&outbound), self.subscribe());
         let mut backoff = INITIAL_RECONNECT_BACKOFF;
         let mut sse_stream = match sub {
@@ -261,17 +255,22 @@ impl BundlePoller {
                         debug!("Block env channel closed, shutting down");
                         break;
                     }
-                    self.record_block_number();
-                    debug!("Block env changed, refetching all bundles");
-                    self.fetch_and_forward(&outbound).await;
+                    // Run the refetch under the BlockConstruction span built by
+                    // EnvTask, so its sim.ru.number / sim.host.number fields
+                    // attach to anything the refetch logs.
+                    let span = self
+                        .envs
+                        .borrow()
+                        .as_ref()
+                        .map_or_else(tracing::Span::none, |env| env.clone_span());
+                    async {
+                        debug!("Block env changed, refetching all bundles");
+                        self.fetch_and_forward(&outbound).await;
+                    }
+                    .instrument(span)
+                    .await;
                 }
             }
-        }
-    }
-
-    fn record_block_number(&self) {
-        if let Some(env) = self.envs.borrow().as_ref() {
-            Span::current().record("block_number", env.rollup_block_number());
         }
     }
 

--- a/src/tasks/cache/system.rs
+++ b/src/tasks/cache/system.rs
@@ -27,7 +27,7 @@ impl CacheTasks {
         let (tx_receiver, tx_poller) = tx_poller.spawn();
 
         // Bundle Poller pulls bundles from the cache
-        let bundle_poller = BundlePoller::new();
+        let bundle_poller = BundlePoller::new(self.block_env.clone());
         let (bundle_receiver, bundle_poller) = bundle_poller.spawn();
 
         // Set up the cache task

--- a/tests/bundle_poller_test.rs
+++ b/tests/bundle_poller_test.rs
@@ -2,15 +2,18 @@
 
 use builder::test_utils::{setup_logging, setup_test_config};
 use eyre::Result;
+use futures_util::TryStreamExt;
+use init4_bin_base::perms::tx_cache::BuilderTxCache;
 
 #[tokio::test]
 async fn test_bundle_poller_roundtrip() -> Result<()> {
     setup_logging();
     setup_test_config();
 
-    let bundle_poller = builder::tasks::cache::BundlePoller::new();
+    let config = builder::config();
+    let tx_cache = BuilderTxCache::new(config.tx_pool_url.clone(), config.oauth_token());
 
-    let _ = bundle_poller.check_bundle_cache().await?;
+    let _bundles: Vec<_> = tx_cache.stream_bundles().try_collect().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Mirrors #259 (tx-poller SSE) for bundles. Replaces the 1s polling loop in `BundlePoller` with an SSE subscription to `/bundles/feed` via `BuilderTxCache::subscribe_bundles` (newly exposed by the SDK, matched by the tx-pool-webservice endpoint).

The structure matches `TxPoller` exactly:
- Initial `full_fetch` paginates through `stream_bundles` to seed the cache on startup.
- `subscribe` opens the SSE stream and yields `CachedBundle`s in real time.
- On stream error / stream end, reconnects with exponential backoff (1s → 30s cap), racing the sleep against the block-env watcher so an env change wins and triggers a fresh full refetch immediately.
- On block-env change, the full_fetch runs again to cover anything missed during disconnection.
- `NotOurSlot` is logged at trace level (expected when the builder is not slot-permissioned) in both the full-fetch and subscribe paths — avoids spurious warn-level noise.

The public `check_bundle_cache()` wrapper is dropped; the integration test now uses `BuilderTxCache::stream_bundles` directly, matching the style of `tx_poller_test.rs`.

## Related Issue

Stacked on #259.

## Testing

- [x] `make fmt` passes
- [x] `make clippy` passes
- [x] `make test` passes
- [x] `cargo doc --no-deps` passes with `-D warnings`
- [x] `cargo test --features test-utils --no-run` builds all integration tests
- [ ] Exercise against a live tx-pool-webservice to verify SSE reconnect and env-driven refetch behavior end-to-end