### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "builder"
-version = "1.0.0"
+version = "1.0.1"
 description = "signet builder example"
 
 edition = "2024"


### PR DESCRIPTION
## Summary

- Bumps `builder` from `1.0.0` to `1.0.1`. The `1.0.0` release shipped a Docker image that fails to run on amd64 hosts with `exec /usr/local/bin/zenith-builder-example: exec format error`, because the shared GHCR and ECR workflows in `init4tech/actions` produced single-arch (arm64-only) images. The shared workflow fixes are in init4tech/actions#128 — once that lands, tagging `v1.0.1` here will produce proper multi-arch manifest lists for both registries.

## Test plan

- [ ] Merge init4tech/actions#128 first
- [ ] Tag `v1.0.1` after this merges and verify both registries publish manifest lists with `linux/amd64` and `linux/arm64`:
  - `docker manifest inspect <ecr-repo>/zenith-builder-example:1.0.1`
  - `docker manifest inspect ghcr.io/init4tech/builder:1.0.1`
- [ ] Pull and run on an amd64 host (no `exec format error`)
- [ ] Pull and run on an arm64 host

🤖 Generated with [Claude Code](https://claude.com/claude-code)