### PR TITLE
chore: bump signet-sdk to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,13 +2386,13 @@ dependencies = [
  "reqwest",
  "reth-chainspec",
  "signet-block-processor",
- "signet-bundle",
- "signet-constants",
+ "signet-bundle 0.17.1",
+ "signet-constants 0.17.1",
  "signet-genesis",
  "signet-sim",
- "signet-tx-cache",
- "signet-types",
- "signet-zenith",
+ "signet-tx-cache 0.17.1",
+ "signet-types 0.17.1",
+ "signet-zenith 0.17.1",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4997,8 +4997,8 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
- "signet-constants",
- "signet-tx-cache",
+ "signet-constants 0.16.2",
+ "signet-tx-cache 0.16.2",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -11104,9 +11104,9 @@ dependencies = [
  "reth",
  "reth-chainspec",
  "serde",
- "signet-extract",
- "signet-types",
- "signet-zenith",
+ "signet-extract 0.16.2",
+ "signet-types 0.16.2",
+ "signet-zenith 0.16.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11127,13 +11127,13 @@ dependencies = [
  "reth-exex",
  "reth-node-api",
  "signet-blobber",
- "signet-constants",
+ "signet-constants 0.16.2",
  "signet-db",
- "signet-evm",
- "signet-extract",
- "signet-journal",
+ "signet-evm 0.16.2",
+ "signet-extract 0.16.2",
+ "signet-journal 0.16.2",
  "signet-node-types",
- "signet-types",
+ "signet-types 0.16.2",
  "tracing",
  "trevm",
 ]
@@ -11146,8 +11146,24 @@ checksum = "dafb04a643cee29180ce8ae2067c81691417bc6ca6ac350146652a3f84576685"
 dependencies = [
  "alloy",
  "serde",
- "signet-evm",
- "signet-types",
+ "signet-evm 0.16.2",
+ "signet-types 0.16.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "trevm",
+]
+
+[[package]]
+name = "signet-bundle"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ec2c9c90905b2347d10a2dd08a170f863e6803eb674e1ad047bf1ebc21a671"
+dependencies = [
+ "alloy",
+ "serde",
+ "signet-evm 0.17.1",
+ "signet-types 0.17.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11159,6 +11175,18 @@ name = "signet-constants"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4360f5a5706c7a9d6ddea3b3d8ab7721f7341c5242bc7f3857967f28090568d"
+dependencies = [
+ "alloy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "signet-constants"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696649acaa5a2658ef69ad33317efbcb7a4162e905840e068805c58e440c6754"
 dependencies = [
  "alloy",
  "serde",
@@ -11180,11 +11208,11 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "serde",
- "signet-evm",
- "signet-journal",
+ "signet-evm 0.16.2",
+ "signet-journal 0.16.2",
  "signet-node-types",
- "signet-types",
- "signet-zenith",
+ "signet-types 0.16.2",
+ "signet-zenith 0.16.2",
  "tokio",
  "tracing",
  "trevm",
@@ -11198,10 +11226,27 @@ checksum = "05cd7eb4c1a23f8b3742084283c690d04fda828f8c7aaa232b0d0a8d89861267"
 dependencies = [
  "alloy",
  "bitflags",
- "signet-extract",
- "signet-journal",
- "signet-types",
- "signet-zenith",
+ "signet-extract 0.16.2",
+ "signet-journal 0.16.2",
+ "signet-types 0.16.2",
+ "signet-zenith 0.16.2",
+ "thiserror 2.0.18",
+ "tracing",
+ "trevm",
+]
+
+[[package]]
+name = "signet-evm"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6accaa23b4ef466891c0c04b25a1851848b1ab078349b9c6a93f4dbd1306cc82"
+dependencies = [
+ "alloy",
+ "bitflags",
+ "signet-extract 0.17.1",
+ "signet-journal 0.17.1",
+ "signet-types 0.17.1",
+ "signet-zenith 0.17.1",
  "thiserror 2.0.18",
  "tracing",
  "trevm",
@@ -11214,8 +11259,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f23779af433acdbac5fb7a5e1489f5a1caab72f5337e2ee640c030a3bdcfb6b"
 dependencies = [
  "alloy",
- "signet-types",
- "signet-zenith",
+ "signet-types 0.16.2",
+ "signet-zenith 0.16.2",
+ "tracing",
+]
+
+[[package]]
+name = "signet-extract"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb893dd4354d53a08858cbad90bcde4d00ac8985135e3ebdf8c45b8694bcd723"
+dependencies = [
+ "alloy",
+ "signet-types 0.17.1",
+ "signet-zenith 0.17.1",
  "tracing",
 ]
 
@@ -11228,7 +11285,7 @@ dependencies = [
  "init4-bin-base",
  "serde",
  "serde_json",
- "signet-constants",
+ "signet-constants 0.16.2",
  "thiserror 2.0.18",
 ]
 
@@ -11237,6 +11294,18 @@ name = "signet-journal"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c3c665f734b1cb68ee2a0263032fd171a3737927b4793d11377b8e917f05e7"
+dependencies = [
+ "alloy",
+ "futures-util",
+ "thiserror 2.0.18",
+ "trevm",
+]
+
+[[package]]
+name = "signet-journal"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8be65c6ef88e71c3c5b4d89bb5e67a9c1e7a986e4502bb423acbb99026b566"
 dependencies = [
  "alloy",
  "futures-util",
@@ -11255,24 +11324,24 @@ dependencies = [
  "reth-db",
  "reth-node-api",
  "reth-node-ethereum",
- "signet-zenith",
+ "signet-zenith 0.16.2",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "signet-sim"
-version = "0.16.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8002d4b0a83bdab1568d77de5790a70a1bd2c8d58bb43649299b7b319b5f67e4"
+checksum = "07c0ea1e01a6c3a4fd499a6105469efe535f0c626eafcfcf2deefe194978ff05"
 dependencies = [
  "alloy",
  "lru",
  "parking_lot",
- "signet-bundle",
- "signet-evm",
- "signet-types",
- "signet-zenith",
+ "signet-bundle 0.17.1",
+ "signet-evm 0.17.1",
+ "signet-types 0.17.1",
+ "signet-zenith 0.17.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11291,9 +11360,28 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "signet-bundle",
- "signet-constants",
- "signet-types",
+ "signet-bundle 0.16.2",
+ "signet-constants 0.16.2",
+ "signet-types 0.16.2",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "signet-tx-cache"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938beefdd1b1ac069e82400967aea723711b9380b493bc2b503ca036596af330"
+dependencies = [
+ "alloy",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "signet-bundle 0.17.1",
+ "signet-constants 0.17.1",
+ "signet-types 0.17.1",
  "thiserror 2.0.18",
  "tracing",
  "url",
@@ -11309,8 +11397,22 @@ dependencies = [
  "alloy",
  "chrono",
  "serde",
- "signet-constants",
- "signet-zenith",
+ "signet-constants 0.16.2",
+ "signet-zenith 0.16.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "signet-types"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f688d131ad626a18e1f2bf7d7e4519f45f631022d8eb83e50ac19a98e87f6a"
+dependencies = [
+ "alloy",
+ "chrono",
+ "serde",
+ "signet-constants 0.17.1",
+ "signet-zenith 0.17.1",
  "thiserror 2.0.18",
 ]
 
@@ -11319,6 +11421,18 @@ name = "signet-zenith"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cafc152356fad0f4461af607af6e4151a3a577b55007a60ce5587969127a6e5"
+dependencies = [
+ "alloy",
+ "alloy-core",
+ "serde",
+ "trevm",
+]
+
+[[package]]
+name = "signet-zenith"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b1b9dda5fbc167c6bd6633a6c36b58bded84ee76e4d32556117776066d798b"
 dependencies = [
  "alloy",
  "alloy-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,18 +2379,18 @@ dependencies = [
  "eyre",
  "futures-util",
  "git-version",
- "init4-bin-base",
+ "init4-bin-base 0.20.0",
  "itertools 0.14.0",
  "metrics-util",
  "openssl",
  "reqwest",
  "reth-chainspec",
  "signet-block-processor",
- "signet-bundle 0.17.1",
+ "signet-bundle",
  "signet-constants 0.17.1",
  "signet-genesis",
  "signet-sim",
- "signet-tx-cache 0.17.1",
+ "signet-tx-cache",
  "signet-types 0.17.1",
  "signet-zenith 0.17.1",
  "thiserror 2.0.18",
@@ -4978,6 +4978,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94c64278d765503d752783c7a1f1052f0d41cff51cd1fd258958d94a9a03010"
 dependencies = [
  "alloy",
+ "axum 0.8.9",
+ "chrono",
+ "init4-from-env-derive",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "opentelemetry 0.30.0",
+ "opentelemetry-http 0.30.0",
+ "opentelemetry-otlp 0.30.0",
+ "opentelemetry-semantic-conventions 0.30.0",
+ "opentelemetry_sdk 0.30.0",
+ "rustls",
+ "serde",
+ "signet-constants 0.16.2",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry 0.31.0",
+ "tracing-subscriber 0.3.23",
+ "url",
+]
+
+[[package]]
+name = "init4-bin-base"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be68d63952fda7f0f360ffcfe4a9a854729827893d7b88c86ed6bacaaa9245c"
+dependencies = [
+ "alloy",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
@@ -4997,8 +5026,8 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
- "signet-constants 0.16.2",
- "signet-tx-cache 0.16.2",
+ "signet-constants 0.17.1",
+ "signet-tx-cache",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -11099,7 +11128,7 @@ source = "git+https://github.com/init4tech/node-components?tag=v0.16.0-rc.10#b6b
 dependencies = [
  "alloy",
  "foundry-blob-explorers",
- "init4-bin-base",
+ "init4-bin-base 0.18.0",
  "reqwest",
  "reth",
  "reth-chainspec",
@@ -11120,7 +11149,7 @@ source = "git+https://github.com/init4tech/node-components?tag=v0.16.0-rc.10#b6b
 dependencies = [
  "alloy",
  "eyre",
- "init4-bin-base",
+ "init4-bin-base 0.18.0",
  "metrics",
  "reth",
  "reth-chainspec",
@@ -11134,22 +11163,6 @@ dependencies = [
  "signet-journal 0.16.2",
  "signet-node-types",
  "signet-types 0.16.2",
- "tracing",
- "trevm",
-]
-
-[[package]]
-name = "signet-bundle"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dafb04a643cee29180ce8ae2067c81691417bc6ca6ac350146652a3f84576685"
-dependencies = [
- "alloy",
- "serde",
- "signet-evm 0.16.2",
- "signet-types 0.16.2",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
  "trevm",
 ]
@@ -11282,7 +11295,7 @@ version = "0.16.0-rc.10"
 source = "git+https://github.com/init4tech/node-components?tag=v0.16.0-rc.10#b6b8cb929da7c5ba32ce0794aacb00a3c4fa5f1b"
 dependencies = [
  "alloy",
- "init4-bin-base",
+ "init4-bin-base 0.18.0",
  "serde",
  "serde_json",
  "signet-constants 0.16.2",
@@ -11338,7 +11351,7 @@ dependencies = [
  "alloy",
  "lru",
  "parking_lot",
- "signet-bundle 0.17.1",
+ "signet-bundle",
  "signet-evm 0.17.1",
  "signet-types 0.17.1",
  "signet-zenith 0.17.1",
@@ -11350,9 +11363,9 @@ dependencies = [
 
 [[package]]
 name = "signet-tx-cache"
-version = "0.16.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba06dc92c72b877f042ba141c7ee553c68aab1c6e077a3ba1adb2eae17fdaff4"
+checksum = "938beefdd1b1ac069e82400967aea723711b9380b493bc2b503ca036596af330"
 dependencies = [
  "alloy",
  "eventsource-stream",
@@ -11360,26 +11373,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "signet-bundle 0.16.2",
- "signet-constants 0.16.2",
- "signet-types 0.16.2",
- "thiserror 2.0.18",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "signet-tx-cache"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938beefdd1b1ac069e82400967aea723711b9380b493bc2b503ca036596af330"
-dependencies = [
- "alloy",
- "futures-util",
- "reqwest",
- "serde",
- "signet-bundle 0.17.1",
+ "signet-bundle",
  "signet-constants 0.17.1",
  "signet-types 0.17.1",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "builder"
-version = "1.1.0"
+version = "1.2.0"
 description = "signet builder example"
 
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "zenith-builder-example"
 path = "bin/builder.rs"
 
 [dependencies]
-init4-bin-base = { version = "0.18.0", features = ["perms", "aws", "pylon", "sse"] }
+init4-bin-base = { version = "0.20.0", features = ["perms", "aws", "pylon", "sse"] }
 
 signet-constants = { version = "0.17.0" }
 signet-sim = { version = "0.17.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ path = "bin/builder.rs"
 [dependencies]
 init4-bin-base = { version = "0.18.0", features = ["perms", "aws", "pylon", "sse"] }
 
-signet-constants = { version = "0.16.0-rc.17" }
-signet-sim = { version = "0.16.0-rc.17" }
-signet-tx-cache = { version = "0.16.0-rc.17" }
-signet-types = { version = "0.16.0-rc.17" }
-signet-zenith = { version = "0.16.0-rc.17" }
+signet-constants = { version = "0.17.0" }
+signet-sim = { version = "0.17.0" }
+signet-tx-cache = { version = "0.17.0" }
+signet-types = { version = "0.17.0" }
+signet-zenith = { version = "0.17.0" }
 signet-block-processor = { git = "https://github.com/init4tech/node-components", tag = "v0.16.0-rc.10" }
 signet-genesis = { git = "https://github.com/init4tech/node-components", tag = "v0.16.0-rc.10" }
 
@@ -68,7 +68,7 @@ alloy-hardforks = "0.4.0"
 alloy-chains = "0.2"
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 metrics-util = "0.20"
-signet-bundle = "0.16.0-rc.11"
+signet-bundle = "0.17.0"
 
 [[bench]]
 name = "sim"


### PR DESCRIPTION
## Summary

Bump the published signet-sdk crates and friends to their latest releases so the builder tracks the current SDK line.

**Version bumps:**
- `init4-bin-base` `0.20.0` → `0.21.0`
- `signet-constants`, `signet-sim`, `signet-tx-cache`, `signet-types`, `signet-zenith`: `0.17.0` → `0.18.0`
- `signet-bundle` (dev-dep): `0.17.0` → `0.18.0`

**Dep source changes:**
- `signet-block-processor` and `signet-genesis` move from the `node-components` git tag (`v0.16.0-rc.10`) to crates.io `0.18.0` now that they're published there. Removes the cross-repo pin.

(Branch name still says `bump-signet-sdk-0.17` — historical, kept to preserve PR URL.)

## Test plan

- [ ] `make fmt`
- [ ] `make clippy`
- [ ] `make test`
